### PR TITLE
Introduce git submodule dev-tools

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+dev-tools/.clang-format

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dev-tools"]
+	path = dev-tools
+	url = https://github.com/3rdparty/dev-tools.git


### PR DESCRIPTION
Removed `tools` directory and added git submodule `dev-tools`.
You can treat it as a symlink to the remote repo which contains
all developer's files for working.