### PR TITLE
Introduce 'stout::copy()' to simplify calls to functions that require…

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,6 +71,7 @@ cc_library(
             "atomic-backoff.h",
             "borrowable.h",
             "borrowed_ptr.h",
+            "copy.h",
             "notification.h",
             "stateful-tally.h",
             "thread.h",

--- a/include/stout/copy.h
+++ b/include/stout/copy.h
@@ -1,0 +1,32 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+
+////////////////////////////////////////////////////////////////////////
+
+namespace stout {
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+std::decay_t<T> copy(T&& t) {
+  return std::decay_t<T>(t);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+} // namespace stout
+
+////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
… r-value args