### PR TITLE
Move in 'stout' repo the latest 'stout-flags' stuff

### DIFF
--- a/include/stout/flags/flags.cc
+++ b/include/stout/flags/flags.cc
@@ -156,7 +156,7 @@ void Parser::AddFieldsAndSubcommandsOrExit(google::protobuf::Message& message) {
 
 ////////////////////////////////////////////////////////////////////////
 
-Parser* Parser::TryLookupParserForSubcommand(const std::string& name) {
+Parser* Parser::TryLookupNestedParserForSubcommand(const std::string& name) {
   auto iterator = subcommand_fields_.find(name);
   if (iterator != subcommand_fields_.end()) {
     const google::protobuf::FieldDescriptor* field = iterator->second;
@@ -225,7 +225,7 @@ void Parser::Parse(int* argc, const char*** argv) {
     // argument.
     if (arg.find("--") != 0) {
       // Check if it's a subcommand.
-      Parser* parser = TryLookupParserForSubcommand(arg);
+      Parser* parser = TryLookupNestedParserForSubcommand(arg);
       if (parser != nullptr) {
         // Keep the number of arguments remained before we call 'nested'
         // Parse() function including subcommand name.

--- a/include/stout/flags/flags.h
+++ b/include/stout/flags/flags.h
@@ -47,7 +47,7 @@ class Parser {
   // Helper that fill fields_ and messages_ helpers.
   void AddFieldsAndSubcommandsOrExit(google::protobuf::Message& message);
 
-  Parser* TryLookupParserForSubcommand(const std::string& name);
+  Parser* TryLookupNestedParserForSubcommand(const std::string& name);
 
   // Helper that gets 'google::protobuf::Message*' that we want to
   // populate for the specified field descriptor.

--- a/include/stout/flags/v1/BUILD.bazel
+++ b/include/stout/flags/v1/BUILD.bazel
@@ -3,7 +3,10 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "flag_proto",
-    srcs = [":flag.proto"],
+    srcs = [
+        ":flag.proto",
+        ":subcommand.proto",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         # Well known protos should be included as deps in the

--- a/include/stout/flags/v1/subcommand.proto
+++ b/include/stout/flags/v1/subcommand.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package stout.v1;
+
+import "google/protobuf/descriptor.proto";
+
+message Subcommand {
+  repeated string names = 1;
+  repeated string deprecated_names = 2;
+  string help = 3;
+  // TODO: bool deprecated = 4;
+}
+
+extend google.protobuf.FieldOptions {
+  optional Subcommand subcommand = 1001;
+}

--- a/tests/flags/BUILD.bazel
+++ b/tests/flags/BUILD.bazel
@@ -31,6 +31,7 @@ cc_test(
         "missing_flag_name.cc",
         "overload_parsing.cc",
         "parse.cc",
+        "subcommand_flags.cc",
         "validate.cc",
     ],
     deps = [

--- a/tests/flags/duplicate_flag_name.cc
+++ b/tests/flags/duplicate_flag_name.cc
@@ -8,17 +8,17 @@ TEST(FlagsTest, DuplicateFlagName) {
   EXPECT_DEATH(
       []() {
         test::DuplicateFlagName duplicate_flag_name;
-        auto builder = stout::flags::Parser::Builder(&duplicate_flag_name);
+        auto builder = stout::flags::Parser::Builder(duplicate_flag_name);
         builder.Build();
       }(),
-      "Encountered duplicate flag name 'same' for "
-      "field 'test.DuplicateFlagName.s2'");
+      "Encountered duplicate flag name 'same' for message "
+      "'test.DuplicateFlagName'");
 }
 
 TEST(FlagsTest, DuplicateSucceed) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -40,7 +40,7 @@ TEST(FlagsTest, DuplicateSucceed) {
 TEST(FlagsTest, DuplicateConflict) {
   test::DuplicateFlagsDeath duplicates;
 
-  auto parser = stout::flags::Parser::Builder(&duplicates).Build();
+  auto parser = stout::flags::Parser::Builder(duplicates).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -72,7 +72,7 @@ TEST(FlagsTest, DuplicateConflict) {
 TEST(FlagsTest, DuplicateNonBooleanFlags) {
   test::DuplicateFlagsDeath duplicates;
 
-  auto parser = stout::flags::Parser::Builder(&duplicates).Build();
+  auto parser = stout::flags::Parser::Builder(duplicates).Build();
 
   std::array arguments = {
       "/path/to/program",

--- a/tests/flags/environment_variables.cc
+++ b/tests/flags/environment_variables.cc
@@ -22,14 +22,13 @@ int unsetenv(const char* env_name) {
 TEST(FlagsTest, EnvironmentVariableString) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .IncludeEnvironmentVariablesWithPrefix("STOUT_FLAGS_TEST")
                     .Build();
 
   std::array arguments = {
       "program",
       "--bar",
-      "one",
   };
 
   int argc = arguments.size();
@@ -44,22 +43,20 @@ TEST(FlagsTest, EnvironmentVariableString) {
   unsetenv(env_name);
 
   EXPECT_TRUE(flags.bar());
-  EXPECT_EQ(2, argc);
+  EXPECT_EQ(1, argc);
   EXPECT_EQ("'HELLO world'", flags.foo());
-  EXPECT_STREQ("program", argv[0]);
-  EXPECT_STREQ("one", argv[1]);
+  EXPECT_EQ("program", argv[0]);
 }
 
 TEST(FlagsTest, IncludeEnvironmentVariableWithUnderscoreFailure) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .IncludeEnvironmentVariablesWithPrefix("STOUT_FLAGS_TEST_")
                     .Build();
 
   std::array arguments = {
       "program",
-      "one",
   };
 
   int argc = arguments.size();
@@ -86,13 +83,12 @@ TEST(FlagsTest, IncludeEnvironmentVariableWithUnderscoreFailure) {
 TEST(FlagsTest, EnvironmentVariableWithNoUnderlineInNameFailure) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .IncludeEnvironmentVariablesWithPrefix("STOUT_FLAGS_TEST")
                     .Build();
 
   std::array arguments = {
       "program",
-      "one",
   };
 
   int argc = arguments.size();
@@ -117,14 +113,13 @@ TEST(FlagsTest, EnvironmentVariableWithNoUnderlineInNameFailure) {
 TEST(FlagsTest, EnvironmentVariableWith2Underscores) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .IncludeEnvironmentVariablesWithPrefix("STOUT_FLAGS_TEST_")
                     .Build();
 
   std::array arguments = {
       "program",
       "--foo='hello'",
-      "one",
   };
 
   int argc = arguments.size();
@@ -138,9 +133,8 @@ TEST(FlagsTest, EnvironmentVariableWith2Underscores) {
   parser.Parse(&argc, &argv);
   unsetenv(env_name);
 
-  EXPECT_EQ(2, argc);
+  EXPECT_EQ(1, argc);
   EXPECT_EQ("'HELLO world'", flags._s());
   EXPECT_EQ("'hello'", flags.foo());
-  EXPECT_STREQ("program", argv[0]);
-  EXPECT_STREQ("one", argv[1]);
+  EXPECT_EQ("program", argv[0]);
 }

--- a/tests/flags/environment_variables.cc
+++ b/tests/flags/environment_variables.cc
@@ -44,8 +44,8 @@ TEST(FlagsTest, EnvironmentVariableString) {
 
   EXPECT_TRUE(flags.bar());
   EXPECT_EQ(1, argc);
-  EXPECT_EQ("'HELLO world'", flags.foo());
-  EXPECT_EQ("program", argv[0]);
+  EXPECT_STREQ("'HELLO world'", flags.foo().c_str());
+  EXPECT_STREQ("program", argv[0]);
 }
 
 TEST(FlagsTest, IncludeEnvironmentVariableWithUnderscoreFailure) {
@@ -134,7 +134,7 @@ TEST(FlagsTest, EnvironmentVariableWith2Underscores) {
   unsetenv(env_name);
 
   EXPECT_EQ(1, argc);
-  EXPECT_EQ("'HELLO world'", flags._s());
-  EXPECT_EQ("'hello'", flags.foo());
-  EXPECT_EQ("program", argv[0]);
+  EXPECT_STREQ("'HELLO world'", flags._s().c_str());
+  EXPECT_STREQ("'hello'", flags.foo().c_str());
+  EXPECT_STREQ("program", argv[0]);
 }

--- a/tests/flags/help.cc
+++ b/tests/flags/help.cc
@@ -7,7 +7,7 @@
 TEST(FlagsTest, Help) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",

--- a/tests/flags/missing_flag_name.cc
+++ b/tests/flags/missing_flag_name.cc
@@ -6,7 +6,7 @@ TEST(FlagsTest, MissingFlagName) {
   EXPECT_DEATH(
       []() {
         test::MissingFlagName missing_flag_name;
-        auto builder = stout::flags::Parser::Builder(&missing_flag_name);
+        auto builder = stout::flags::Parser::Builder(missing_flag_name);
         builder.Build();
       }(),
       "Missing at least one flag name in 'names' for "
@@ -17,9 +17,31 @@ TEST(FlagsTest, MissingFlagHelp) {
   EXPECT_DEATH(
       []() {
         test::MissingFlagHelp missing_flag_help;
-        auto builder = stout::flags::Parser::Builder(&missing_flag_help);
+        auto builder = stout::flags::Parser::Builder(missing_flag_help);
         builder.Build();
       }(),
       "Missing flag 'help' for "
       "field 'test.MissingFlagHelp.s'");
+}
+
+TEST(FlagsTest, MissingSubcommandName) {
+  EXPECT_DEATH(
+      []() {
+        test::FlagsWithSubcommandMissingName flags;
+        auto builder = stout::flags::Parser::Builder(flags);
+        builder.Build();
+      }(),
+      "Missing at least one subcommand name in 'names' for "
+      "field 'test.FlagsWithSubcommandMissingName.build'");
+}
+
+TEST(FlagsTest, MissingSubcommandHelp) {
+  EXPECT_DEATH(
+      []() {
+        test::FlagsWithSubcommandMissingHelp flags;
+        auto builder = stout::flags::Parser::Builder(flags);
+        builder.Build();
+      }(),
+      "Missing subcommand 'help' for "
+      "field 'test.FlagsWithSubcommandMissingHelp.info_subcommand'");
 }

--- a/tests/flags/overload_parsing.cc
+++ b/tests/flags/overload_parsing.cc
@@ -9,7 +9,7 @@
 TEST(FlagsTest, DefaultOverloadParsingDuration) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .Build();
 
   std::array arguments = {
@@ -32,9 +32,9 @@ TEST(FlagsTest, DefaultOverloadParsingDuration) {
 TEST(FlagsTest, OverloadParsingDuration) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .OverloadParsing<google::protobuf::Duration>(
-                        [](const std::string& value, auto* duration) {
+                        [](const std::string& value, auto& duration) {
                           return std::optional<std::string>("unimplemented");
                         })
                     .Build();
@@ -64,13 +64,13 @@ TEST(FlagsTest, MultipleOverloadParsingDuration) {
   test::Flags flags;
 
   auto operation = [&flags]() {
-    auto parser = stout::flags::Parser::Builder(&flags)
+    auto parser = stout::flags::Parser::Builder(flags)
                       .OverloadParsing<google::protobuf::Duration>(
-                          [](const std::string& value, auto* duration) {
+                          [](const std::string& value, auto& duration) {
                             return std::optional<std::string>("unimplemented");
                           })
                       .OverloadParsing<google::protobuf::Duration>(
-                          [](const std::string& value, auto* duration) {
+                          [](const std::string& value, auto& duration) {
                             return std::optional<std::string>("unimplemented");
                           })
                       .Build();

--- a/tests/flags/parse.cc
+++ b/tests/flags/parse.cc
@@ -7,7 +7,7 @@
 TEST(FlagsTest, ParseRequired) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -30,7 +30,7 @@ TEST(FlagsTest, ParseRequired) {
 TEST(FlagsTest, ParseStringWithSingleQuotes) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -48,7 +48,7 @@ TEST(FlagsTest, ParseStringWithSingleQuotes) {
 TEST(FlagsTest, ParseStringWithDoubleQuotes) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -66,7 +66,7 @@ TEST(FlagsTest, ParseStringWithDoubleQuotes) {
 TEST(FlagsTest, ParseStringWithoutSingleOrDoubleQuotes) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -84,7 +84,7 @@ TEST(FlagsTest, ParseStringWithoutSingleOrDoubleQuotes) {
 TEST(FlagsTest, ParseSpaceStringWithoutAnyQuotes) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -102,7 +102,7 @@ TEST(FlagsTest, ParseSpaceStringWithoutAnyQuotes) {
 TEST(FlagsTest, ParseImplicitBoolean) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -121,7 +121,7 @@ TEST(FlagsTest, ParseImplicitBoolean) {
 TEST(FlagsTest, ParseExplicitBoolean) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -140,7 +140,7 @@ TEST(FlagsTest, ParseExplicitBoolean) {
 TEST(FlagsTest, ParseNegatedBoolean) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -159,14 +159,12 @@ TEST(FlagsTest, ParseNegatedBoolean) {
 TEST(FlagsTest, ModifiedArgcArgv) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
       "--foo='hello world'",
-      "one",
       "--bar",
-      "two",
   };
 
   int argc = arguments.size();
@@ -177,17 +175,15 @@ TEST(FlagsTest, ModifiedArgcArgv) {
   EXPECT_TRUE(flags.bar());
   EXPECT_EQ("'hello world'", flags.foo());
 
-  EXPECT_EQ(3, argc);
+  EXPECT_EQ(1, argc);
 
-  EXPECT_STREQ("/path/to/program", argv[0]);
-  EXPECT_STREQ("one", argv[1]);
-  EXPECT_STREQ("two", argv[2]);
+  EXPECT_EQ("/path/to/program", argv[0]);
 }
 
 TEST(FlagsTest, UnknownNonNegatedFlag) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -212,7 +208,7 @@ TEST(FlagsTest, UnknownNonNegatedFlag) {
 TEST(FlagsTest, UnknownNegatedFlag) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -237,7 +233,7 @@ TEST(FlagsTest, UnknownNegatedFlag) {
 TEST(FlagsTest, IncorrectNegatedBooleanFlag) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -263,7 +259,7 @@ TEST(FlagsTest, IncorrectNegatedBooleanFlag) {
 TEST(FlagsTest, NonBooleanFlagWithPrefix) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -289,7 +285,7 @@ TEST(FlagsTest, NonBooleanFlagWithPrefix) {
 TEST(FlagsTest, NonBooleanFlagWithEmptyValue) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -315,7 +311,7 @@ TEST(FlagsTest, NonBooleanFlagWithEmptyValue) {
 TEST(FlagsTest, ProtobufTextFormatParserError) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",

--- a/tests/flags/parse.cc
+++ b/tests/flags/parse.cc
@@ -60,7 +60,7 @@ TEST(FlagsTest, ParseStringWithDoubleQuotes) {
 
   parser.Parse(&argc, &argv);
 
-  EXPECT_EQ("\"hello world\"", flags.foo());
+  EXPECT_STREQ("\"hello world\"", flags.foo().c_str());
 }
 
 TEST(FlagsTest, ParseStringWithoutSingleOrDoubleQuotes) {
@@ -78,7 +78,7 @@ TEST(FlagsTest, ParseStringWithoutSingleOrDoubleQuotes) {
 
   parser.Parse(&argc, &argv);
 
-  EXPECT_EQ("hello", flags.foo());
+  EXPECT_STREQ("hello", flags.foo().c_str());
 }
 
 TEST(FlagsTest, ParseSpaceStringWithoutAnyQuotes) {
@@ -96,7 +96,7 @@ TEST(FlagsTest, ParseSpaceStringWithoutAnyQuotes) {
 
   parser.Parse(&argc, &argv);
 
-  EXPECT_EQ("hello world", flags.foo());
+  EXPECT_STREQ("hello world", flags.foo().c_str());
 }
 
 TEST(FlagsTest, ParseImplicitBoolean) {
@@ -173,11 +173,11 @@ TEST(FlagsTest, ModifiedArgcArgv) {
   parser.Parse(&argc, &argv);
 
   EXPECT_TRUE(flags.bar());
-  EXPECT_EQ("'hello world'", flags.foo());
+  EXPECT_STREQ("'hello world'", flags.foo().c_str());
 
   EXPECT_EQ(1, argc);
 
-  EXPECT_EQ("/path/to/program", argv[0]);
+  EXPECT_STREQ("/path/to/program", argv[0]);
 }
 
 TEST(FlagsTest, UnknownNonNegatedFlag) {

--- a/tests/flags/subcommand_flags.cc
+++ b/tests/flags/subcommand_flags.cc
@@ -82,10 +82,10 @@ TEST(FlagsTest, SubcommandAndUnknownArguments) {
 
   EXPECT_TRUE(flags.has_build());
   EXPECT_EQ(4, argc);
-  EXPECT_EQ("program", argv[0]);
-  EXPECT_EQ("some", argv[1]);
-  EXPECT_EQ("unknown", argv[2]);
-  EXPECT_EQ("arguments", argv[3]);
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_STREQ("some", argv[1]);
+  EXPECT_STREQ("unknown", argv[2]);
+  EXPECT_STREQ("arguments", argv[3]);
   EXPECT_TRUE(flags.b());
   EXPECT_EQ(13, flags.build().other_flag());
 }
@@ -109,7 +109,7 @@ TEST(FlagsTest, SimpleSubcommandBuildSucceed) {
 
   EXPECT_TRUE(flags.has_build());
   EXPECT_EQ(1, argc);
-  EXPECT_EQ("program", argv[0]);
+  EXPECT_STREQ("program", argv[0]);
   EXPECT_TRUE(flags.b());
   EXPECT_EQ(13, flags.build().other_flag());
 }
@@ -133,9 +133,9 @@ TEST(FlagsTest, SimpleSubcommandInfoSucceed) {
 
   EXPECT_TRUE(flags.has_info_subcommand());
   EXPECT_EQ(1, argc);
-  EXPECT_EQ("program", argv[0]);
+  EXPECT_STREQ("program", argv[0]);
   EXPECT_TRUE(flags.b());
-  EXPECT_EQ("hello world", flags.info_subcommand().info());
+  EXPECT_STREQ("hello world", flags.info_subcommand().info().c_str());
 }
 
 TEST(FlagsTest, DuplicateSubcommands) {
@@ -200,7 +200,7 @@ TEST(FlagsTest, DuplicateSubcommandFlagNameForEnclosingLevel) {
 
   EXPECT_TRUE(flags.has_build());
   EXPECT_EQ(1, argc);
-  EXPECT_EQ("program", argv[0]);
+  EXPECT_STREQ("program", argv[0]);
   EXPECT_EQ(1, flags.other_flag());
   EXPECT_EQ(2, flags.build().other_flag());
 }
@@ -253,10 +253,10 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed1) {
   EXPECT_FALSE(flags.has_sub2());
   EXPECT_FALSE(flags.sub1().has_info_subcommand());
   EXPECT_EQ(1, argc);
-  EXPECT_EQ("program", argv[0]);
-  EXPECT_EQ("hello world", flags.flag());
-  EXPECT_EQ("Ben", flags.other());
-  EXPECT_EQ("Artur", flags.sub1().another());
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_STREQ("hello world", flags.flag().c_str());
+  EXPECT_STREQ("Ben", flags.other().c_str());
+  EXPECT_STREQ("Artur", flags.sub1().another().c_str());
   EXPECT_EQ(13, flags.sub1().num());
   EXPECT_EQ(1, flags.sub1().build().other_flag());
 }
@@ -287,12 +287,12 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed2) {
   EXPECT_FALSE(flags.sub1().has_build());
   EXPECT_TRUE(flags.sub1().has_info_subcommand());
   EXPECT_EQ(1, argc);
-  EXPECT_EQ("program", argv[0]);
-  EXPECT_EQ("hello world", flags.flag());
-  EXPECT_EQ("Ben", flags.other());
-  EXPECT_EQ("Artur", flags.sub1().another());
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_STREQ("hello world", flags.flag().c_str());
+  EXPECT_STREQ("Ben", flags.other().c_str());
+  EXPECT_STREQ("Artur", flags.sub1().another().c_str());
   EXPECT_EQ(13, flags.sub1().num());
-  EXPECT_EQ("ciao", flags.sub1().info_subcommand().info());
+  EXPECT_STREQ("ciao", flags.sub1().info_subcommand().info().c_str());
 }
 
 TEST(FlagsTest, ComplicatedSubcommandSucceed3) {
@@ -320,11 +320,11 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed3) {
   EXPECT_FALSE(flags.sub2().has_build());
   EXPECT_TRUE(flags.sub2().has_info_subcommand());
   EXPECT_EQ(1, argc);
-  EXPECT_EQ("program", argv[0]);
-  EXPECT_EQ("hello world", flags.flag());
-  EXPECT_EQ("Ben", flags.other());
-  EXPECT_EQ("Artur", flags.sub2().s());
-  EXPECT_EQ("some info", flags.sub2().info_subcommand().info());
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_STREQ("hello world", flags.flag().c_str());
+  EXPECT_STREQ("Ben", flags.other().c_str());
+  EXPECT_STREQ("Artur", flags.sub2().s().c_str());
+  EXPECT_STREQ("some info", flags.sub2().info_subcommand().info().c_str());
 }
 
 TEST(FlagsTest, ComplicatedSubcommandSucceed4) {
@@ -352,9 +352,9 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed4) {
   EXPECT_TRUE(flags.sub2().has_build());
   EXPECT_FALSE(flags.sub2().has_info_subcommand());
   EXPECT_EQ(1, argc);
-  EXPECT_EQ("program", argv[0]);
-  EXPECT_EQ("hello world", flags.flag());
-  EXPECT_EQ("Ben", flags.other());
-  EXPECT_EQ("Artur", flags.sub2().s());
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_STREQ("hello world", flags.flag().c_str());
+  EXPECT_STREQ("Ben", flags.other().c_str());
+  EXPECT_STREQ("Artur", flags.sub2().s().c_str());
   EXPECT_EQ(13, flags.sub2().build().other_flag());
 }

--- a/tests/flags/subcommand_flags.cc
+++ b/tests/flags/subcommand_flags.cc
@@ -1,0 +1,360 @@
+#include <array>
+
+#include "gtest/gtest.h"
+#include "stout/flags/flags.h"
+#include "tests/flags/test.pb.h"
+
+TEST(FlagsTest, MissingSubcommandExtension) {
+  EXPECT_DEATH(
+      []() {
+        test::SubcommandFlagsWithoutExtension flag;
+        auto builder = stout::flags::Parser::Builder(flag);
+        builder.Build();
+      }(),
+      "Every field of the 'oneof subcommand' must be"
+      " annotated with a stout.v1.subcommand option");
+}
+
+TEST(FlagsTest, IncorrectSubcommandExtension) {
+  EXPECT_DEATH(
+      []() {
+        test::FlagsWithIncorrectExtension flag;
+        auto builder = stout::flags::Parser::Builder(flag);
+        builder.Build();
+      }(),
+      "stout.v1.subcommand option should be annotated on fields"
+      " that are only inside 'oneof subcommand'");
+}
+
+TEST(FlagsTest, IncorrectOneofName) {
+  EXPECT_DEATH(
+      []() {
+        test::IncorrectOneofName flag;
+        auto builder = stout::flags::Parser::Builder(flag);
+        builder.Build();
+      }(),
+      "'oneof' field must have 'subcommand' name. "
+      "Other names are illegal");
+}
+
+TEST(FlagsTest, SubcommandFlagExtension) {
+  EXPECT_DEATH(
+      []() {
+        test::SubcommandFlagExtension flag;
+        auto builder = stout::flags::Parser::Builder(flag);
+        builder.Build();
+      }(),
+      "Every field of the 'oneof subcommand' must be"
+      " annotated with a stout.v1.subcommand option");
+}
+
+TEST(FlagsTest, DuplicateSubcommandFields) {
+  EXPECT_DEATH(
+      []() {
+        test::DuplicateSubcommandFields flag;
+        auto builder = stout::flags::Parser::Builder(flag);
+        builder.Build();
+      }(),
+      "Encountered duplicate subcommand name 'build'"
+      " for message 'test.DuplicateSubcommandFields'");
+}
+
+TEST(FlagsTest, SubcommandAndUnknownArguments) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=13",
+      "--",
+      "some",
+      "unknown",
+      "arguments",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_build());
+  EXPECT_EQ(4, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("some", argv[1]);
+  EXPECT_EQ("unknown", argv[2]);
+  EXPECT_EQ("arguments", argv[3]);
+  EXPECT_TRUE(flags.b());
+  EXPECT_EQ(13, flags.build().other_flag());
+}
+
+TEST(FlagsTest, SimpleSubcommandBuildSucceed) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=13",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_build());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_TRUE(flags.b());
+  EXPECT_EQ(13, flags.build().other_flag());
+}
+
+TEST(FlagsTest, SimpleSubcommandInfoSucceed) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "info_subcommand",
+      "--info=hello world",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_TRUE(flags.b());
+  EXPECT_EQ("hello world", flags.info_subcommand().info());
+}
+
+TEST(FlagsTest, DuplicateSubcommands) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "info_subcommand",
+      "--info=hello world",
+      "info_subcommand",
+      "--info=oops",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "Encountered unknown argument 'info_subcommand'");
+}
+
+TEST(FlagsTest, DuplicateSubcommandFlags) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=1",
+      "--other_flag=2",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "Encountered duplicate flag 'other_flag'");
+}
+
+TEST(FlagsTest, DuplicateSubcommandFlagNameForEnclosingLevel) {
+  test::DuplicateEnclosingFlagName flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--other_flag=1",
+      "build",
+      "--other_flag=2",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_build());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ(1, flags.other_flag());
+  EXPECT_EQ(2, flags.build().other_flag());
+}
+
+TEST(FlagsTest, SubcommandFailSettingTwoOneofFlagsAtOnce) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=1",
+      "info_subcommand",
+      "--info=hello",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "Encountered unknown argument 'info_subcommand'");
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed1) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub1",
+      "--another=Artur",
+      "--num=13",
+      "build",
+      "--other_flag=1",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub1());
+  EXPECT_TRUE(flags.sub1().has_build());
+  EXPECT_FALSE(flags.has_sub2());
+  EXPECT_FALSE(flags.sub1().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub1().another());
+  EXPECT_EQ(13, flags.sub1().num());
+  EXPECT_EQ(1, flags.sub1().build().other_flag());
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed2) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub1",
+      "--another=Artur",
+      "--num=13",
+      "info_subcommand",
+      "--info=ciao",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub1());
+  EXPECT_FALSE(flags.has_sub2());
+  EXPECT_FALSE(flags.sub1().has_build());
+  EXPECT_TRUE(flags.sub1().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub1().another());
+  EXPECT_EQ(13, flags.sub1().num());
+  EXPECT_EQ("ciao", flags.sub1().info_subcommand().info());
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed3) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub2",
+      "--s=Artur",
+      "info_subcommand",
+      "--info=some info",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub2());
+  EXPECT_FALSE(flags.has_sub1());
+  EXPECT_FALSE(flags.sub2().has_build());
+  EXPECT_TRUE(flags.sub2().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub2().s());
+  EXPECT_EQ("some info", flags.sub2().info_subcommand().info());
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed4) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub2",
+      "--s=Artur",
+      "build",
+      "--other_flag=13",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub2());
+  EXPECT_FALSE(flags.has_sub1());
+  EXPECT_TRUE(flags.sub2().has_build());
+  EXPECT_FALSE(flags.sub2().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub2().s());
+  EXPECT_EQ(13, flags.sub2().build().other_flag());
+}

--- a/tests/flags/test.proto
+++ b/tests/flags/test.proto
@@ -4,6 +4,7 @@ package test;
 
 import "google/protobuf/duration.proto";
 import "include/stout/flags/v1/flag.proto";
+import "include/stout/flags/v1/subcommand.proto";
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -114,6 +115,312 @@ message DuplicateFlagsDeath {
       help: "help"
     }
   ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message BuildFlag {
+  int32 other_flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "other_flag" ]
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message InfoFlag {
+  string info = 1 [
+    (stout.v1.flag) = {
+      names: [ "info" ]
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message FlagsWithSubcommandMissingName {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message FlagsWithSubcommandMissingHelp {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandFlagsWithoutExtension {
+  bool b = 1 [
+    (stout.v1.flag) = {
+      names: [ "b" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message FlagsWithIncorrectExtension {
+  bool b = 1 [
+    (stout.v1.subcommand) = {
+      names: [ "build" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message IncorrectOneofName {
+  oneof other {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandFlagExtension {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.flag) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SimpleSubcommandSucceed {
+  bool b = 1 [
+    (stout.v1.flag) = {
+      names: [ "b", "bb" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message ComplicatedSubcommandMessage {
+  string flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "flag" ]
+      help: "help"
+    }
+  ];
+
+  string other = 2 [
+    (stout.v1.flag) = {
+      names: [ "other" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    SubcommandSubMessage1 sub1 = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "sub1" ]
+        help: "help"
+      }
+    ];
+    SubcommandSubMessage2 sub2 = 4 [
+      (stout.v1.subcommand) = {
+        names: [ "sub2" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandSubMessage1 {
+  string another = 1 [
+    (stout.v1.flag) = {
+      names: [ "another" ]
+      help: "help"
+    }
+  ];
+
+  int32 num = 2 [
+    (stout.v1.flag) = {
+      names: [ "num" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 4 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandSubMessage2 {
+  string s = 1 [
+    (stout.v1.flag) = {
+      names: [ "s" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message DuplicateEnclosingFlagName {
+  int32 other_flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "other_flag" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message DuplicateSubcommandFields {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/flags/validate.cc
+++ b/tests/flags/validate.cc
@@ -7,7 +7,7 @@
 TEST(FlagsTest, Validate) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .Validate(
                         "'bar' must be true",
                         [](const auto& flags) {


### PR DESCRIPTION
Since we are going to deprecate `3rdparty/stout-flags` - we move all updated code from there in this repo.