### PR TITLE
Introduce positional arguments

### DIFF
--- a/include/stout/flags/flags.h
+++ b/include/stout/flags/flags.h
@@ -9,6 +9,7 @@
 #include "google/protobuf/io/tokenizer.h"
 #include "google/protobuf/text_format.h"
 #include "stout/flags/v1/flag.pb.h"
+#include "stout/flags/v1/positional_argument.pb.h"
 #include "stout/flags/v1/subcommand.pb.h"
 
 ////////////////////////////////////////////////////////////////////////

--- a/include/stout/flags/v1/BUILD.bazel
+++ b/include/stout/flags/v1/BUILD.bazel
@@ -5,6 +5,7 @@ proto_library(
     name = "flag_proto",
     srcs = [
         ":flag.proto",
+        ":positional_argument.proto",
         ":subcommand.proto",
     ],
     visibility = ["//visibility:public"],

--- a/include/stout/flags/v1/positional_argument.proto
+++ b/include/stout/flags/v1/positional_argument.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package stout.v1;
+
+import "google/protobuf/descriptor.proto";
+
+message Argument {
+  repeated string names = 1;
+  repeated string deprecated_names = 2;
+  string help = 3;
+  bool required = 4;
+  uint32 position = 5;
+}
+
+extend google.protobuf.FieldOptions {
+  optional Argument argument = 1002;
+}

--- a/include/stout/flags/v1/positional_argument.proto
+++ b/include/stout/flags/v1/positional_argument.proto
@@ -2,16 +2,68 @@ syntax = "proto3";
 
 package stout.v1;
 
+// For defining our own options.
 import "google/protobuf/descriptor.proto";
 
+// Message which represents a positional argument.
+// NOTE: a positional argument is a bare value, and
+// its position in a list of arguments identifies it.
+// For example:
+//     echo 'hello' ' ' 'world'
+// 'hello', ' ', 'world' - are the positional args
+// from the command line.
+//
+// In our implementation of flags we expect that this
+// arguments will be passed without any name in the same
+// order that they are defined in the user-defined
+// protobuf message (we added string 'name' for
+// printing out the help message and errors).
+// NOTE: this is definition order not field index order:
+// For example:
+//    message RandomIndexFieldOrder{
+//      string str1 = 2 [
+//        (stout.v1.argument) = {
+//          name: "str1"
+//          help: "help"
+//        }
+//      ];
+//
+//      string str2 = 1 [
+//        (stout.v1.argument) = {
+//          name: "str2"
+//          help: "help"
+//        }
+//      ];
+//    }
+//
+// In the example above you can see that user has defined
+// proto message with random field index order (the first
+// positional argument has index '2', the second has index
+// '1'). But anyway the order of positional arguments that
+// we expect from the command line will be the same as the
+// order in which positional arguments are defined in the
+// protobuf message (str1 , str2).
+// Check 'tests/flags/positional_arguments.cc' for more
+// information.
+
+// Positional arguments might be at the end of the command
+// line or even might be intermingled with other flags or
+// subcommands. For example the following below is the
+// valid input in the command line:
+//     ./program --top_level_flag1=1 pos_arg1 subcommand 45 --flag2='hello' 5
+// So 'pos_arg1', '45', '5' - are valid positional
+// arguments.
 message Argument {
-  repeated string names = 1;
-  repeated string deprecated_names = 2;
-  string help = 3;
-  bool required = 4;
-  uint32 position = 5;
+  // For printing out help. We make it be non-optional
+  // cause we want to store this name and field pointer
+  // for printing out help message as well as we use this
+  // name to print out consistent error.
+  string name = 1;
+  // For printing out help.
+  string help = 2;
 }
 
+// Extend a level-field option.
 extend google.protobuf.FieldOptions {
   optional Argument argument = 1002;
 }

--- a/tests/flags/BUILD.bazel
+++ b/tests/flags/BUILD.bazel
@@ -31,6 +31,7 @@ cc_test(
         "missing_flag_name.cc",
         "overload_parsing.cc",
         "parse.cc",
+        "positional_arguments.cc",
         "subcommand_flags.cc",
         "validate.cc",
     ],

--- a/tests/flags/environment_variables.cc
+++ b/tests/flags/environment_variables.cc
@@ -44,7 +44,7 @@ TEST(FlagsTest, EnvironmentVariableString) {
 
   EXPECT_TRUE(flags.bar());
   EXPECT_EQ(1, argc);
-  EXPECT_STREQ("'HELLO world'", flags.foo().c_str());
+  EXPECT_EQ("'HELLO world'", flags.foo());
   EXPECT_STREQ("program", argv[0]);
 }
 
@@ -134,7 +134,7 @@ TEST(FlagsTest, EnvironmentVariableWith2Underscores) {
   unsetenv(env_name);
 
   EXPECT_EQ(1, argc);
-  EXPECT_STREQ("'HELLO world'", flags._s().c_str());
-  EXPECT_STREQ("'hello'", flags.foo().c_str());
+  EXPECT_EQ("'HELLO world'", flags._s());
+  EXPECT_EQ("'hello'", flags.foo());
   EXPECT_STREQ("program", argv[0]);
 }

--- a/tests/flags/missing_flag_name.cc
+++ b/tests/flags/missing_flag_name.cc
@@ -20,8 +20,7 @@ TEST(FlagsTest, MissingFlagHelp) {
         auto builder = stout::flags::Parser::Builder(missing_flag_help);
         builder.Build();
       }(),
-      "Missing flag 'help' for "
-      "field 'test.MissingFlagHelp.s'");
+      "Missing 'help' for field 'test.MissingFlagHelp.s'");
 }
 
 TEST(FlagsTest, MissingSubcommandName) {

--- a/tests/flags/parse.cc
+++ b/tests/flags/parse.cc
@@ -60,7 +60,7 @@ TEST(FlagsTest, ParseStringWithDoubleQuotes) {
 
   parser.Parse(&argc, &argv);
 
-  EXPECT_STREQ("\"hello world\"", flags.foo().c_str());
+  EXPECT_EQ("\"hello world\"", flags.foo());
 }
 
 TEST(FlagsTest, ParseStringWithoutSingleOrDoubleQuotes) {
@@ -78,7 +78,7 @@ TEST(FlagsTest, ParseStringWithoutSingleOrDoubleQuotes) {
 
   parser.Parse(&argc, &argv);
 
-  EXPECT_STREQ("hello", flags.foo().c_str());
+  EXPECT_EQ("hello", flags.foo());
 }
 
 TEST(FlagsTest, ParseSpaceStringWithoutAnyQuotes) {
@@ -96,7 +96,7 @@ TEST(FlagsTest, ParseSpaceStringWithoutAnyQuotes) {
 
   parser.Parse(&argc, &argv);
 
-  EXPECT_STREQ("hello world", flags.foo().c_str());
+  EXPECT_EQ("hello world", flags.foo());
 }
 
 TEST(FlagsTest, ParseImplicitBoolean) {
@@ -173,7 +173,7 @@ TEST(FlagsTest, ModifiedArgcArgv) {
   parser.Parse(&argc, &argv);
 
   EXPECT_TRUE(flags.bar());
-  EXPECT_STREQ("'hello world'", flags.foo().c_str());
+  EXPECT_EQ("'hello world'", flags.foo());
 
   EXPECT_EQ(1, argc);
 

--- a/tests/flags/positional_arguments.cc
+++ b/tests/flags/positional_arguments.cc
@@ -1,0 +1,267 @@
+#include <array>
+
+#include "gtest/gtest.h"
+#include "stout/flags/flags.h"
+#include "tests/flags/test.pb.h"
+
+TEST(PositionalArguments, RenameSucceed) {
+  test::Rename rename;
+
+  auto parser = stout::flags::Parser::Builder(rename).Build();
+
+  std::array arguments = {
+      "rename",
+      "foo.cc",
+      "bar.cc",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  // We expect argc be equal to 1 cause all flags/pos args
+  // which were parsed successfully should be consumed and
+  // removed from 'argv'.
+  EXPECT_EQ(1, argc);
+  EXPECT_STREQ("rename", argv[0]);
+  EXPECT_EQ("foo.cc", rename.cur_file_name());
+  EXPECT_EQ("bar.cc", rename.new_file_name());
+}
+
+TEST(PositionalArguments, RenameFailOnMissingRequiredArgument) {
+  test::Rename rename;
+
+  auto parser = stout::flags::Parser::Builder(rename).Build();
+
+  std::array arguments = {
+      "rename",
+      "bar.cc",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "rename: Failed while parsing and validating flags:"
+      "\?\n\?\n"
+      ". Positional argument 'new_file' not parsed but required");
+}
+
+TEST(PositionalArguments, BuildFileSucceed) {
+  test::ProcessFile msg;
+
+  auto parser = stout::flags::Parser::Builder(msg).Build();
+
+  std::array arguments = {
+      "program",
+      "build",
+      "--debug",
+      "foo.cc",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_EQ(1, argc);
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_FALSE(msg.has_rename());
+  EXPECT_TRUE(msg.has_build());
+  EXPECT_TRUE(msg.build().debug_mode());
+  EXPECT_EQ("foo.cc", msg.build().file());
+}
+
+TEST(PositionalArguments, ProcessFileRenameSucceed) {
+  test::ProcessFile msg;
+
+  auto parser = stout::flags::Parser::Builder(msg).Build();
+
+  std::array arguments = {
+      "program",
+      "rename",
+      "foo.cc",
+      "bar.cc",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_EQ(1, argc);
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_TRUE(msg.has_rename());
+  EXPECT_FALSE(msg.has_build());
+  EXPECT_EQ("foo.cc", msg.rename().cur_file_name());
+  EXPECT_EQ("bar.cc", msg.rename().new_file_name());
+}
+
+TEST(PositionalArguments, RandomOrderFieldIndexes) {
+  test::RandomOrderFieldIndexes msg;
+
+  auto parser = stout::flags::Parser::Builder(msg).Build();
+
+  std::array arguments = {
+      "program",
+      "first value",
+      "second value",
+      "third value",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_EQ(1, argc);
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_EQ("first value", msg.str1());
+  EXPECT_EQ("second value", msg.str2());
+  EXPECT_EQ("third value", msg.str3());
+}
+
+TEST(PositionalArguments, BuildFileFailOnMissingRequiredArgument) {
+  test::ProcessFile msg;
+
+  auto parser = stout::flags::Parser::Builder(msg).Build();
+
+  std::array arguments = {
+      "program",
+      "build",
+      "--debug=true",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "build: Failed while parsing and validating flags:"
+      "\?\n\?\n"
+      ". Positional argument 'file_name' not parsed but required");
+}
+
+TEST(PositionalArguments, RedundantPositionalArguments) {
+  test::ProcessFile msg;
+
+  auto parser = stout::flags::Parser::Builder(msg).Build();
+
+  std::array arguments = {
+      "program",
+      "build",
+      "main.cc",
+      "--debug=true",
+      "45",
+      "redundant",
+      "true",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "build: Failed while parsing and validating flags:"
+      "\?\n\?\n"
+      ". Encountered unknown flag '45'"
+      "\?\n\?\n"
+      ". Encountered unknown flag 'redundant'"
+      "\?\n\?\n"
+      ". Encountered unknown flag 'true'");
+}
+
+TEST(PositionalArguments, IllegalPositionalArgument1) {
+  test::IllegalPositionalArg1 msg;
+
+  EXPECT_DEATH(
+      stout::flags::Parser::Builder(msg).Build(),
+      "Field 'test.IllegalPositionalArg1.num' with 'stout::v1::argument'"
+      " extension must have string type");
+}
+
+TEST(PositionalArguments, IllegalPositionalArgument2) {
+  test::IllegalPositionalArg2 msg;
+
+  EXPECT_DEATH(
+      stout::flags::Parser::Builder(msg).Build(),
+      "Missing name for field 'test.IllegalPositionalArg2.str'");
+}
+
+TEST(PositionalArguments, IllegalPositionalArgument3) {
+  test::IllegalPositionalArg3 msg;
+
+  EXPECT_DEATH(
+      stout::flags::Parser::Builder(msg).Build(),
+      "Missing 'help' for field 'test.IllegalPositionalArg3.str'");
+}
+
+TEST(PositionalArguments, MoreComplicatedCase1) {
+  test::TopLevelArguments msg;
+
+  auto parser = stout::flags::Parser::Builder(msg).Build();
+
+  std::array arguments = {
+      "program",
+      "--top_level_flag1=42",
+      "top_pos_arg1",
+      "--top_level_flag2='ciao'",
+      "C++",
+      "sub1",
+      "--sub1_flag=13",
+      "hello world",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_EQ(1, argc);
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_FALSE(msg.has_sub2());
+  EXPECT_TRUE(msg.has_sub1());
+  EXPECT_EQ(42, msg.top_level_flag1());
+  EXPECT_EQ("'ciao'", msg.top_level_flag2());
+  EXPECT_EQ("top_pos_arg1", msg.top_pos_arg1());
+  EXPECT_EQ("C++", msg.top_pos_arg2());
+  EXPECT_EQ(13, msg.sub1().sub1_flag());
+  EXPECT_EQ("hello world", msg.sub1().sub1_pos_arg());
+}
+
+TEST(PositionalArguments, MoreComplicatedCase2) {
+  test::TopLevelArguments msg;
+
+  auto parser = stout::flags::Parser::Builder(msg).Build();
+
+  std::array arguments = {
+      "program",
+      "--top_level_flag1=100",
+      "--top_level_flag2='ciao'",
+      "some",
+      "value",
+      "sub2",
+      "la vita e bella come caramella",
+      "--sub2_flag=1994",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_EQ(1, argc);
+  EXPECT_STREQ("program", argv[0]);
+  EXPECT_FALSE(msg.has_sub1());
+  EXPECT_TRUE(msg.has_sub2());
+  EXPECT_EQ(100, msg.top_level_flag1());
+  EXPECT_EQ("'ciao'", msg.top_level_flag2());
+  EXPECT_EQ("some", msg.top_pos_arg1());
+  EXPECT_EQ("value", msg.top_pos_arg2());
+  EXPECT_EQ(1994, msg.sub2().sub2_flag());
+  EXPECT_EQ(
+      "la vita e bella come caramella",
+      msg.sub2().sub2_pos_arg());
+}

--- a/tests/flags/subcommand_flags.cc
+++ b/tests/flags/subcommand_flags.cc
@@ -135,7 +135,7 @@ TEST(FlagsTest, SimpleSubcommandInfoSucceed) {
   EXPECT_EQ(1, argc);
   EXPECT_STREQ("program", argv[0]);
   EXPECT_TRUE(flags.b());
-  EXPECT_STREQ("hello world", flags.info_subcommand().info().c_str());
+  EXPECT_EQ("hello world", flags.info_subcommand().info());
 }
 
 TEST(FlagsTest, DuplicateSubcommands) {
@@ -157,7 +157,9 @@ TEST(FlagsTest, DuplicateSubcommands) {
 
   EXPECT_DEATH(
       parser.Parse(&argc, &argv),
-      "Encountered unknown argument 'info_subcommand'");
+      ". Encountered duplicate flag 'info'"
+      "\?\n\?\n"
+      ". Encountered unknown flag 'info_subcommand'");
 }
 
 TEST(FlagsTest, DuplicateSubcommandFlags) {
@@ -224,7 +226,9 @@ TEST(FlagsTest, SubcommandFailSettingTwoOneofFlagsAtOnce) {
 
   EXPECT_DEATH(
       parser.Parse(&argc, &argv),
-      "Encountered unknown argument 'info_subcommand'");
+      ". Encountered unknown flag 'info'"
+      "\?\n\?\n"
+      ". Encountered unknown flag 'info_subcommand'");
 }
 
 TEST(FlagsTest, ComplicatedSubcommandSucceed1) {
@@ -254,9 +258,9 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed1) {
   EXPECT_FALSE(flags.sub1().has_info_subcommand());
   EXPECT_EQ(1, argc);
   EXPECT_STREQ("program", argv[0]);
-  EXPECT_STREQ("hello world", flags.flag().c_str());
-  EXPECT_STREQ("Ben", flags.other().c_str());
-  EXPECT_STREQ("Artur", flags.sub1().another().c_str());
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub1().another());
   EXPECT_EQ(13, flags.sub1().num());
   EXPECT_EQ(1, flags.sub1().build().other_flag());
 }
@@ -288,11 +292,11 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed2) {
   EXPECT_TRUE(flags.sub1().has_info_subcommand());
   EXPECT_EQ(1, argc);
   EXPECT_STREQ("program", argv[0]);
-  EXPECT_STREQ("hello world", flags.flag().c_str());
-  EXPECT_STREQ("Ben", flags.other().c_str());
-  EXPECT_STREQ("Artur", flags.sub1().another().c_str());
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub1().another());
   EXPECT_EQ(13, flags.sub1().num());
-  EXPECT_STREQ("ciao", flags.sub1().info_subcommand().info().c_str());
+  EXPECT_EQ("ciao", flags.sub1().info_subcommand().info());
 }
 
 TEST(FlagsTest, ComplicatedSubcommandSucceed3) {
@@ -321,10 +325,10 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed3) {
   EXPECT_TRUE(flags.sub2().has_info_subcommand());
   EXPECT_EQ(1, argc);
   EXPECT_STREQ("program", argv[0]);
-  EXPECT_STREQ("hello world", flags.flag().c_str());
-  EXPECT_STREQ("Ben", flags.other().c_str());
-  EXPECT_STREQ("Artur", flags.sub2().s().c_str());
-  EXPECT_STREQ("some info", flags.sub2().info_subcommand().info().c_str());
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub2().s());
+  EXPECT_EQ("some info", flags.sub2().info_subcommand().info());
 }
 
 TEST(FlagsTest, ComplicatedSubcommandSucceed4) {
@@ -353,8 +357,8 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed4) {
   EXPECT_FALSE(flags.sub2().has_info_subcommand());
   EXPECT_EQ(1, argc);
   EXPECT_STREQ("program", argv[0]);
-  EXPECT_STREQ("hello world", flags.flag().c_str());
-  EXPECT_STREQ("Ben", flags.other().c_str());
-  EXPECT_STREQ("Artur", flags.sub2().s().c_str());
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub2().s());
   EXPECT_EQ(13, flags.sub2().build().other_flag());
 }

--- a/tests/flags/test.proto
+++ b/tests/flags/test.proto
@@ -425,3 +425,209 @@ message DuplicateSubcommandFields {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+
+message Rename {
+  string cur_file_name = 1 [
+    (stout.v1.argument) = {
+      name: "current_file"
+      help: "help"
+    }
+  ];
+
+  string new_file_name = 2 [
+    (stout.v1.argument) = {
+      name: "new_file"
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message BuildFile {
+  bool debug_mode = 1 [
+    (stout.v1.flag) = {
+      names: [ "debug" ]
+      help: "help"
+    }
+  ];
+
+  string file = 2 [
+    (stout.v1.argument) = {
+      name: "file_name"
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message ProcessFile {
+  oneof subcommand {
+    BuildFile build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+
+    Rename rename = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "rename" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// This message is illegal because we expect that users
+// will define fields with 'stout.v1.argument' extension
+// of the type 'string'.
+message IllegalPositionalArg1 {
+  int32 num = 1 [
+    (stout.v1.argument) = {
+      name: "num"
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// Illegal setup where the user doesn't define name option.
+message IllegalPositionalArg2 {
+  string str = 1 [
+    (stout.v1.argument) = {
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// Illegal setup where the user doesn't define help option.
+message IllegalPositionalArg3 {
+  string str = 1 [
+    (stout.v1.argument) = {
+      name: "str"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// This message demonstrates that if users define positional
+// arguments with random field index order - anyway the order
+// of positional arguments that we expect from the command
+// line will be the same as the order in which they are
+// defined in protobuf message.
+message RandomOrderFieldIndexes {
+  string str1 = 2 [
+    (stout.v1.argument) = {
+      name: "str1"
+      help: "help"
+    }
+  ];
+
+  string str2 = 3 [
+    (stout.v1.argument) = {
+      name: "str2"
+      help: "help"
+    }
+  ];
+
+  string str3 = 1 [
+    (stout.v1.argument) = {
+      name: "str3"
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// More complicated case for positional arguments.
+message TopLevelArguments {
+  int32 top_level_flag1 = 1 [
+    (stout.v1.flag) = {
+      names: [ "top_level_flag1" ]
+      help: "help"
+    }
+  ];
+
+  string top_level_flag2 = 2 [
+    (stout.v1.flag) = {
+      names: [ "top_level_flag2" ]
+      help: "help"
+    }
+  ];
+
+  string top_pos_arg1 = 3 [
+    (stout.v1.argument) = {
+      name: "top_pos_arg1"
+      help: "help"
+    }
+  ];
+
+  string top_pos_arg2 = 4 [
+    (stout.v1.argument) = {
+      name: "top_pos_arg2"
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    Subcommand1 sub1 = 5 [
+      (stout.v1.subcommand) = {
+        names: [ "sub1" ]
+        help: "help"
+      }
+    ];
+    Subcommand2 sub2 = 6 [
+      (stout.v1.subcommand) = {
+        names: [ "sub2" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message Subcommand1 {
+  int32 sub1_flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "sub1_flag" ]
+      help: "help"
+    }
+  ];
+
+  string sub1_pos_arg = 2 [
+    (stout.v1.argument) = {
+      name: "sub1_pos_arg1"
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message Subcommand2 {
+  int32 sub2_flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "sub2_flag" ]
+      help: "help"
+    }
+  ];
+
+  string sub2_pos_arg = 2 [
+    (stout.v1.argument) = {
+      name: "sub2_pos_arg"
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////

--- a/tests/flags/test.proto
+++ b/tests/flags/test.proto
@@ -4,6 +4,7 @@ package test;
 
 import "google/protobuf/duration.proto";
 import "include/stout/flags/v1/flag.proto";
+import "include/stout/flags/v1/positional_argument.proto";
 import "include/stout/flags/v1/subcommand.proto";
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added `positional_argument.proto` and make it build via `proto_library`
rule in the `stout/v1/BUILD.bazel` (phase 1).
Also added all the logic which introduces parsing [`positional arguments`](https://pythonconquerstheuniverse.wordpress.com/2010/07/25/command-line-syntax-some-basic-concepts/) from the command line (phase 2).