### PR TITLE
Stop overriding `--spawn_strategy` in checks

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Build
         run: |
           bazel build \
-            --spawn_strategy=local \
             -c dbg \
             --strip="never" \
             ...
@@ -53,7 +52,6 @@ jobs:
       - name: Test
         run: |
           bazel test \
-            --spawn_strategy=local \
             -c dbg \
             --strip="never" \
             --test_output=errors \


### PR DESCRIPTION
This doesn't appear to be needed, and relying on the default value of
`sandboxed` seems cleaner.

See discussion in https://github.com/3rdparty/eventuals/pull/323#discussion_r920407063.
