### PR TITLE
Replace manual stringification with 'fmt::format'

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -93,6 +93,7 @@ cc_library(
         "@boost//:get_pointer",
         "@boost//:lexical_cast",
         "@boost//:variant",
+        "@com_github_fmtlib_fmt//:fmt",
         "@com_github_google_glog//:glog",
         "@com_github_kazuho_picojson//:picojson",
         "@com_github_tencent_rapidjson//:rapidjson",

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -85,14 +85,14 @@ def repos(external = True, repo_mapping = {}):
         repo_mapping = repo_mapping,
     )
 
-    # Copied and then modified to use 'commit' and 'shallow_since'
+    # Copied and then modified to use the latest 'commit' and 'shallow_since'
     # rather than tracking the 'master' branch from:
     # https://github.com/fmtlib/fmt/tree/master/support/bazel
     maybe(
         git_repository,
         name = "com_github_fmtlib_fmt",
-        commit = "b6f4ceaed0a0a24ccf575fab6c56dd50ccf6f1a9",
-        shallow_since = "1641508515 -0800",
+        commit = "81f1cc74a776581cdef8659d176049d3aeb743c6",
+        shallow_since = "1658588611 -0700",
         remote = "https://github.com/fmtlib/fmt",
         patch_cmds = [
             "mv support/bazel/.bazelrc .bazelrc",

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -85,6 +85,33 @@ def repos(external = True, repo_mapping = {}):
         repo_mapping = repo_mapping,
     )
 
+    # Copied and then modified to use 'commit' and 'shallow_since'
+    # rather than tracking the 'master' branch from:
+    # https://github.com/fmtlib/fmt/tree/master/support/bazel
+    maybe(
+        git_repository,
+        name = "com_github_fmtlib_fmt",
+        commit = "b6f4ceaed0a0a24ccf575fab6c56dd50ccf6f1a9",
+        shallow_since = "1641508515 -0800",
+        remote = "https://github.com/fmtlib/fmt",
+        patch_cmds = [
+            "mv support/bazel/.bazelrc .bazelrc",
+            "mv support/bazel/.bazelversion .bazelversion",
+            "mv support/bazel/BUILD.bazel BUILD.bazel",
+            "mv support/bazel/WORKSPACE.bazel WORKSPACE.bazel",
+        ],
+        # Windows-related patch commands are only needed in the case MSYS2 is not installed.
+        # More details about the installation process of MSYS2 on Windows systems can be found here:
+        # https://docs.bazel.build/versions/main/install-windows.html#installing-compilers-and-language-runtimes
+        # Even if MSYS2 is installed the Windows related patch commands can still be used.
+        patch_cmds_win = [
+            "Move-Item -Path support/bazel/.bazelrc -Destination .bazelrc",
+            "Move-Item -Path support/bazel/.bazelversion -Destination .bazelversion",
+            "Move-Item -Path support/bazel/BUILD.bazel -Destination BUILD.bazel",
+            "Move-Item -Path support/bazel/WORKSPACE.bazel -Destination WORKSPACE.bazel",
+        ],
+    )
+
     if external:
         maybe(
             git_repository,

--- a/include/stout/base64.h
+++ b/include/stout/base64.h
@@ -16,8 +16,8 @@
 #include <functional>
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/foreach.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -126,7 +126,7 @@ inline Try<std::string> decode(
     }
 
     if (!isBase64(c)) {
-      return Error("Invalid character '" + stringify(c) + "'");
+      return Error(fmt::format("Invalid character '{}'", c));
     }
 
     array4[i++] = c;

--- a/include/stout/bytes.h
+++ b/include/stout/bytes.h
@@ -21,7 +21,6 @@
 
 #include "stout/abort.h"
 #include "stout/numify.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 #include "stout/try.h"
 

--- a/include/stout/elf.h
+++ b/include/stout/elf.h
@@ -21,12 +21,13 @@
 #include <string>
 #include <vector>
 
+#include "fmt/format.h"
+#include "fmt/ranges.h"
 #include "stout/error.h"
 #include "stout/foreach.h"
 #include "stout/nothing.h"
 #include "stout/option.h"
 #include "stout/result.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 #include "stout/try.h"
 #include "stout/version.h"
@@ -171,9 +172,10 @@ class File {
 
     // The note in a `.note.ABI-tag` section must have `type == 1`.
     if (type != 1) {
-      return Error("Corrupt tag type '" + stringify(type) +
-                   "' from"
-                   " entry in '.note.ABI-tag' section");
+      return Error(
+          fmt::format(
+              "Corrupt tag type '{}' from entry in '.note.ABI-tag' section",
+              type));
     }
 
     // Linux mandates `name == GNU`.
@@ -193,9 +195,10 @@ class File {
         (uint32_t*) ((char*) descriptor + descriptor_size));
 
     if (version.size() != 4 || version[0] != 0) {
-      return Error("Corrupt version '" + stringify(version) +
-                   "'"
-                   " from entry in '.note.ABI-tag' section");
+      return Error(
+          fmt::format(
+              "Corrupt version '[{}]' from entry in '.note.ABI-tag' section",
+              fmt::join(version, ", ")));
     }
 
     return Version(version[1], version[2], version[3]);

--- a/include/stout/gzip.h
+++ b/include/stout/gzip.h
@@ -16,10 +16,10 @@
 
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/abort.h"
 #include "stout/error.h"
 #include "stout/os/strerror.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -73,7 +73,7 @@ class GzipError : public Error {
       case Z_MEM_ERROR: return "Z_MEM_ERROR";
       case Z_BUF_ERROR: return "Z_BUF_ERROR";
       case Z_VERSION_ERROR: return "Z_VERSION_ERROR";
-      default: return "Unknown error " + stringify(code);
+      default: return fmt::format("Unknown error {}", code);
     }
   }
 
@@ -188,7 +188,7 @@ inline Try<std::string> compress(
   // Verify the level is within range.
   if (!(level == Z_DEFAULT_COMPRESSION
         || (level >= Z_NO_COMPRESSION && level <= Z_BEST_COMPRESSION))) {
-    return Error("Invalid compression level: " + stringify(level));
+    return Error(fmt::format("Invalid compression level: {}", level));
   }
 
   z_stream_s stream;

--- a/include/stout/internal/windows/attributes.h
+++ b/include/stout/internal/windows/attributes.h
@@ -15,6 +15,12 @@
 #include <string>
 
 #include "stout/error.h"
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string stringify(const std::wstring& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 #include "stout/try.h"
 #include "stout/windows.h"

--- a/include/stout/internal/windows/longpath.h
+++ b/include/stout/internal/windows/longpath.h
@@ -18,6 +18,12 @@
 
 #include "stout/os/constants.h"
 #include "stout/path.h"
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string stringify(const std::wstring& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 
 ////////////////////////////////////////////////////////////////////////

--- a/include/stout/ip.h
+++ b/include/stout/ip.h
@@ -47,6 +47,7 @@
 #include <string>
 #include <vector>
 
+#include "fmt/format.h"
 #include "stout/abort.h"
 #include "stout/bits.h"
 #include "stout/check.h"
@@ -56,7 +57,6 @@
 #include "stout/option.h"
 #include "stout/os/strerror.h"
 #include "stout/result.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 #include "stout/try.h"
 #include "stout/unreachable.h"
@@ -122,7 +122,8 @@ class IP {
     if (family_ == AF_INET) {
       return storage_.in_;
     } else {
-      return Error("Cannot create in_addr from family: " + stringify(family_));
+      return Error(
+          fmt::format("Cannot create in_addr from family: {}", family_));
     }
   }
 
@@ -132,7 +133,7 @@ class IP {
       return storage_.in6_;
     } else {
       return Error(
-          "Cannot create in6_addr from family: " + stringify(family_));
+          fmt::format("Cannot create in6_addr from family: {}", family_));
     }
   }
 
@@ -425,7 +426,7 @@ inline Try<IP> IP::parse(const std::string& value, int family) {
       return Error("Failed to parse IP as either IPv4 or IPv6:" + value);
     }
     default:
-      return Error("Unsupported family type: " + stringify(family));
+      return Error(fmt::format("Unsupported family type: {}", family));
   }
 }
 
@@ -471,7 +472,8 @@ inline Try<IP> IP::create(const struct sockaddr& addr) {
       return IP(addr6.sin6_addr);
     }
     default: {
-      return Error("Unsupported family type: " + stringify(addr.sa_family));
+      return Error(
+          fmt::format("Unsupported family type: {}", addr.sa_family));
     }
   }
 }
@@ -489,8 +491,10 @@ inline std::ostream& operator<<(std::ostream& stream, const IP& ip) {
         // We do not expect inet_ntop to fail because all parameters
         // passed in are valid.
         ABORT(
-            "Failed to get human-readable IPv4 for "
-            + stringify(ntohl(in.s_addr)) + ": " + os::strerror(errno));
+            fmt::format(
+                "Failed to get human-readable IPv4 for {}:{}",
+                ntohl(in.s_addr),
+                os::strerror(errno)));
       }
       return stream << buffer;
     }
@@ -517,7 +521,7 @@ inline Try<IP::Network> IP::Network::parse(
 
   if (tokens.size() != 2) {
     return Error(
-        "Unexpected number of '/' detected: " + stringify(tokens.size()));
+        fmt::format("Unexpected number of '/' detected: {}", tokens.size()));
   }
 
   // Parse the IP address.
@@ -554,9 +558,11 @@ inline Try<IP::Network> IP::Network::create(
     const IP& netmask) {
   if (address.family() != netmask.family()) {
     return Error(
-        "The network families of the IP address '"
-        + stringify(address.family()) + "' and the IP netmask '"
-        + stringify(netmask.family()) + "' do not match");
+        fmt::format(
+            "The network families of the IP address '{}'"
+            " and the IP netmask '{}' do not match",
+            address.family(),
+            netmask.family()));
   }
 
   switch (address.family()) {

--- a/include/stout/mac.h
+++ b/include/stout/mac.h
@@ -47,7 +47,6 @@
 #include "stout/error.h"
 #include "stout/none.h"
 #include "stout/result.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 #include "stout/try.h"
 

--- a/include/stout/net.h
+++ b/include/stout/net.h
@@ -54,7 +54,6 @@
 #include "stout/os/close.h"
 #include "stout/os/int_fd.h"
 #include "stout/os/open.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 #ifdef _WIN32

--- a/include/stout/os/posix/bootid.h
+++ b/include/stout/os/posix/bootid.h
@@ -16,11 +16,12 @@
 
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/error.h"
 #include "stout/os/read.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 #include "stout/try.h"
+
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include "stout/os/sysctl.h"
 #endif // __APPLE__ || __FreeBSD__

--- a/include/stout/os/posix/copyfile.h
+++ b/include/stout/os/posix/copyfile.h
@@ -14,13 +14,13 @@
 
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/error.h"
 #include "stout/nothing.h"
 #include "stout/option.h"
 #include "stout/os/shell.h"
 #include "stout/os/stat.h"
 #include "stout/path.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -67,7 +67,7 @@ inline Try<Nothing> copyfile(
   }
 
   if (!(WIFEXITED(status.get()) && WEXITSTATUS(status.get()) == 0)) {
-    return Error("cp failed with status: " + stringify(status.get()));
+    return Error(fmt::format("cp failed with status: {}", status.get()));
   }
 
   return Nothing();

--- a/include/stout/os/posix/fork.h
+++ b/include/stout/os/posix/fork.h
@@ -27,6 +27,7 @@
 #include <set>
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/abort.h"
 #include "stout/check.h"
 #include "stout/error.h"
@@ -36,7 +37,6 @@
 #include "stout/os/ftruncate.h"
 #include "stout/os/process.h"
 #include "stout/os/strerror.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -283,7 +283,7 @@ struct Fork {
     int instance = forks.fetch_add(1);
 
     std::string name =
-        "/stout-forks-" + stringify(getpid()) + stringify(instance);
+        fmt::format("/stout-forks-{}{}", status.get(), instance);
 
     int fd = shm_open(name.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
 

--- a/include/stout/os/posix/ftruncate.h
+++ b/include/stout/os/posix/ftruncate.h
@@ -14,9 +14,9 @@
 
 #include <sys/types.h>
 
+#include "fmt/format.h"
 #include "stout/error.h"
 #include "stout/nothing.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -28,8 +28,10 @@ namespace os {
 inline Try<Nothing> ftruncate(int fd, off_t length) {
   if (::ftruncate(fd, length) != 0) {
     return ErrnoError(
-        "Failed to truncate file at file descriptor '"
-        + stringify(fd) + "' to " + stringify(length) + " bytes.");
+        fmt::format(
+            "Failed to truncate file at file descriptor '{}' to {} bytes",
+            fd,
+            length));
   }
 
   return Nothing();

--- a/include/stout/os/posix/rmdir.h
+++ b/include/stout/os/posix/rmdir.h
@@ -18,10 +18,10 @@
 
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/error.h"
 #include "stout/nothing.h"
 #include "stout/os/exists.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -127,7 +127,7 @@ inline Try<Nothing> rmdir(
   }
 
   if (errorCount > 0) {
-    return Error("Failed to delete " + stringify(errorCount) + " paths");
+    return Error(fmt::format("Failed to delete {} paths", errorCount));
   }
 
   return Nothing();

--- a/include/stout/os/pstree.h
+++ b/include/stout/os/pstree.h
@@ -15,12 +15,12 @@
 #include <list>
 #include <set>
 
+#include "fmt/format.h"
 #include "stout/error.h"
 #include "stout/foreach.h"
 #include "stout/none.h"
 #include "stout/option.h"
 #include "stout/os/process.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -56,7 +56,7 @@ inline Try<ProcessTree> pstree(
     }
   }
 
-  return Error("No process found at " + stringify(pid));
+  return Error(fmt::format("No process found at ", pid));
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/include/stout/os/raw/environment.h
+++ b/include/stout/os/raw/environment.h
@@ -16,9 +16,9 @@
 
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/foreach.h"
 #include "stout/json.h"
-#include "stout/stringify.h"
 
 #ifdef __APPLE__
 #include <crt_externs.h> // For _NSGetEnviron().
@@ -142,8 +142,8 @@ class Envp {
     size_t index = 0;
 
     for (auto it = map.begin(); it != map.end(); ++it) {
-      environment[stringify(it->first)] = stringify(it->second);
-      std::string entry = stringify(it->first) + "=" + stringify(it->second);
+      environment[fmt::format("{}", it->first)] = fmt::format("{}", it->second);
+      std::string entry = fmt::format("{}={}", it->first, it->second);
       envp[index] = new char[entry.size() + 1];
       ::memcpy(envp[index], entry.c_str(), entry.size() + 1);
       ++index;
@@ -163,7 +163,7 @@ class Envp {
         const std::string& key,
         const JSON::Value& value,
         object.values) {
-      environment[key] = stringify(value.as<JSON::String>().value);
+      environment[key] = fmt::format("{}", value.as<JSON::String>().value);
       std::string entry = key + "=" + value.as<JSON::String>().value;
       envp[index] = new char[entry.size() + 1];
       ::memcpy(envp[index], entry.c_str(), entry.size() + 1);

--- a/include/stout/os/read.h
+++ b/include/stout/os/read.h
@@ -28,7 +28,6 @@
 #include "stout/result.h"
 #include "stout/try.h"
 #ifdef _WIN32
-#include "stout/stringify.h"
 #include "stout/windows.h"
 #endif // _WIN32
 

--- a/include/stout/os/windows/bootid.h
+++ b/include/stout/os/windows/bootid.h
@@ -15,7 +15,7 @@
 #include <chrono>
 #include <string>
 
-#include "stout/stringify.h"
+#include "fmt/format.h"
 #include "stout/try.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -42,7 +42,7 @@ inline Try<std::string> bootId() {
                                  boot_time.time_since_epoch())
                                  .count();
 
-  return stringify(boot_time_secs);
+  return fmt::format("{}", boot_time_secs);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/include/stout/os/windows/environment.h
+++ b/include/stout/os/windows/environment.h
@@ -16,6 +16,12 @@
 #include <memory>
 #include <string>
 
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string stringify(const std::wstring& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 
 ////////////////////////////////////////////////////////////////////////

--- a/include/stout/os/windows/getcwd.h
+++ b/include/stout/os/windows/getcwd.h
@@ -15,6 +15,12 @@
 #include "stout/check.h"
 #include "stout/error.h"
 #include "stout/internal/windows/longpath.h"
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string stringify(const std::wstring& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 #include "stout/try.h"
 #include "stout/windows.h"

--- a/include/stout/os/windows/getenv.h
+++ b/include/stout/os/windows/getenv.h
@@ -17,6 +17,12 @@
 
 #include "stout/none.h"
 #include "stout/option.h"
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string wide_stringify(const std::string& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 #include "stout/windows.h"
 

--- a/include/stout/os/windows/jobobject.h
+++ b/include/stout/os/windows/jobobject.h
@@ -17,11 +17,18 @@
 #include <set>
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/bytes.h"
 #include "stout/none.h"
 #include "stout/nothing.h"
 #include "stout/os/os.h"
 #include "stout/os/process.h"
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string stringify(const std::wstring& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 #include "stout/strings.h"
 #include "stout/try.h"

--- a/include/stout/os/windows/mktemp.h
+++ b/include/stout/os/windows/mktemp.h
@@ -22,6 +22,12 @@
 #include "stout/os/open.h"
 #include "stout/os/temp.h"
 #include "stout/path.h"
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string stringify(const std::wstring& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 #include "stout/try.h"
 #include "stout/windows.h"

--- a/include/stout/os/windows/realpath.h
+++ b/include/stout/os/windows/realpath.h
@@ -18,6 +18,12 @@
 #include "stout/internal/windows/longpath.h"
 #include "stout/internal/windows/reparsepoint.h"
 #include "stout/result.h"
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string stringify(const std::wstring& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 #include "stout/strings.h"
 #include "stout/windows.h"

--- a/include/stout/os/windows/temp.h
+++ b/include/stout/os/windows/temp.h
@@ -15,6 +15,12 @@
 #include <string>
 #include <vector>
 
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string stringify(const std::wstring& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 #include "stout/windows.h"
 

--- a/include/stout/path.h
+++ b/include/stout/path.h
@@ -16,8 +16,8 @@
 #include <utility>
 #include <vector>
 
+#include "fmt/format.h"
 #include "stout/os/constants.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -115,7 +115,7 @@ inline std::string join(
     const std::string& path1,
     const std::string& path2,
     const char _separator = os::PATH_SEPARATOR) {
-  const std::string separator = stringify(_separator);
+  const std::string separator = fmt::format("{}", _separator);
   return strings::remove(
              path1,
              separator,
@@ -255,7 +255,7 @@ class Path {
 
       // Paths containing only slashes result into "/".
       if (end == std::string::npos) {
-        return stringify(separator);
+        return fmt::format("{}", separator);
       }
     }
 
@@ -322,7 +322,7 @@ class Path {
 
     // Paths containing only slashes result in "/".
     if (end == 0) {
-      return stringify(separator);
+      return fmt::format("{}", separator);
     }
 
     // 'end' should point towards the last non slash character
@@ -331,7 +331,7 @@ class Path {
 
     // Paths containing no non slash characters result in "/".
     if (end == std::string::npos) {
-      return stringify(separator);
+      return fmt::format("{}", separator);
     }
 
     return value.substr(0, end + 1);

--- a/include/stout/posix/mac.h
+++ b/include/stout/posix/mac.h
@@ -15,10 +15,10 @@
 #include <ifaddrs.h>
 #include <sys/types.h>
 
+#include "fmt/format.h"
 #include "stout/error.h"
 #include "stout/none.h"
 #include "stout/result.h"
-#include "stout/stringify.h"
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -54,7 +54,7 @@ inline Result<MAC> mac(const std::string& name) {
 
           // Ignore if the address is 0 so that the results are
           // consistent on both OSX and Linux.
-          if (stringify(mac) == "00:00:00:00:00:00") {
+          if (fmt::format("{}", mac) == "00:00:00:00:00:00") {
             continue;
           }
 

--- a/include/stout/protobuf.h
+++ b/include/stout/protobuf.h
@@ -30,6 +30,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "fmt/format.h"
 #include "stout/abort.h"
 #include "stout/base64.h"
 #include "stout/error.h"
@@ -46,7 +47,6 @@
 #include "stout/os/write.h"
 #include "stout/representation.h"
 #include "stout/result.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 #ifdef _WIN32
@@ -166,7 +166,7 @@ Try<Nothing> write(const std::string& path, const T& t, bool sync = false) {
   // We propagate `close` failures if `write` on the file was successful.
   if (write.isSome() && close.isError()) {
     return Error(
-        "Failed to close '" + stringify(fd.get()) + "':" + close.error());
+        fmt::format("Failed to close '{}':{}", fd.get(), close.error()));
   }
 
   return write;
@@ -202,7 +202,7 @@ inline Try<Nothing> append(
   // We propagate `close` failures if `write` on the file was successful.
   if (write.isSome() && close.isError()) {
     return Error(
-        "Failed to close '" + stringify(fd.get()) + "':" + close.error());
+        fmt::format("Failed to close '{}':{}", fd.get(), close.error()));
   }
 
   return write;
@@ -314,8 +314,10 @@ struct Read {
         return None();
       }
       return Error(
-          "Failed to read message of size " + stringify(size)
-          + " bytes: hit EOF unexpectedly, possible corruption");
+          fmt::format(
+              "Failed to read message of size {} bytes: "
+              "hit EOF unexpectedly, possible corruption",
+              size));
     }
 
     // Parse the protobuf from the string.
@@ -1034,7 +1036,7 @@ inline Object protobuf(const google::protobuf::Message& message) {
       case google::protobuf::FieldDescriptor::TYPE_GROUP:
         // Deprecated! We abort here instead of using a Try as return value,
         // because we expect this code path to never be taken.
-        ABORT("Unhandled protobuf field type: " + stringify(field->type()));
+        ABORT(fmt::format("Unhandled protobuf field type: {}", field->type()));
     }
 
     UNREACHABLE();
@@ -1162,7 +1164,9 @@ inline Object protobuf(const google::protobuf::Message& message) {
             // Deprecated! We abort here instead of using a Try as return
             // value, because we expect this code path to never be taken.
             ABORT(
-                "Unhandled protobuf field type: " + stringify(field->type()));
+                fmt::format(
+                    "Unhandled protobuf field type: {}",
+                    field->type()));
         }
       }
       object.values[field->name()] = array;

--- a/include/stout/recordio.h
+++ b/include/stout/recordio.h
@@ -18,11 +18,11 @@
 #include <functional>
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/check.h"
 #include "stout/foreach.h"
 #include "stout/numify.h"
 #include "stout/option.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 ////////////////////////////////////////////////////////////////////////
@@ -67,7 +67,7 @@ class Encoder {
    */
   std::string encode(const T& record) const {
     std::string s = serialize(record);
-    return stringify(s.size()) + "\n" + s;
+    return fmt::format("{}\n{}", s.size(), s);
   }
 
  private:

--- a/include/stout/strings.h
+++ b/include/stout/strings.h
@@ -19,10 +19,10 @@
 #include <string>
 #include <vector>
 
+#include "fmt/format.h"
 #include "foreach.h"
 #include "format.h"
 #include "option.h"
-#include "stringify.h"
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -279,7 +279,7 @@ template <typename T>
 std::stringstream& append(
     std::stringstream& stream,
     T&& value) {
-  stream << ::stringify(std::forward<T>(value));
+  stream << fmt::format("{}", std::forward<T>(value));
   return stream;
 }
 
@@ -358,7 +358,7 @@ inline std::string join(const std::string& separator, const Iterable& i) {
   std::string result;
   typename Iterable::const_iterator iterator = i.begin();
   while (iterator != i.end()) {
-    result += stringify(*iterator);
+    result += fmt::format("{}", *iterator);
     if (++iterator != i.end()) {
       result += separator;
     }

--- a/include/stout/version.h
+++ b/include/stout/version.h
@@ -19,11 +19,11 @@
 #include <string>
 #include <vector>
 
+#include "fmt/format.h"
 #include "stout/check.h"
 #include "stout/error.h"
 #include "stout/numify.h"
 #include "stout/option.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 #include "stout/try.h"
 
@@ -107,9 +107,10 @@ struct Version {
 
     if (numericComponents.size() > maxNumericComponents) {
       return Error(
-          "Version has " + stringify(numericComponents.size())
-          + " components; maximum " + stringify(maxNumericComponents)
-          + " components allowed");
+          fmt::format(
+              "Version has {} components; maximum {} components allowed",
+              numericComponents.size(),
+              maxNumericComponents));
     }
 
     uint32_t versionNumbers[maxNumericComponents] = {0};
@@ -302,9 +303,9 @@ struct Version {
 
     if (firstInvalid != identifier.end()) {
       return Error(
-          "Identifier contains illegal character: "
-          "'"
-          + stringify(*firstInvalid) + "'");
+          fmt::format(
+              "Identifier contains illegal character: '{}'",
+              *firstInvalid));
     }
 
     return None();

--- a/include/stout/windows/mac.h
+++ b/include/stout/windows/mac.h
@@ -15,10 +15,10 @@
 #include <algorithm>
 #include <vector>
 
+#include "fmt/format.h"
 #include "stout/error.h"
 #include "stout/none.h"
 #include "stout/result.h"
-#include "stout/stringify.h"
 #include "stout/windows.h" // For `iphlpapi.h`.
 
 ////////////////////////////////////////////////////////////////////////
@@ -66,7 +66,7 @@ inline Result<MAC> mac(const std::string& name) {
 
         // Ignore if the address is 0 so that the results are
         // consistent across all platforms.
-        if (stringify(mac) == "00:00:00:00:00:00") {
+        if (fmt::format("{}", mac) == "00:00:00:00:00:00") {
           continue;
         }
 

--- a/include/stout/windows/net.h
+++ b/include/stout/windows/net.h
@@ -16,10 +16,17 @@
 #include <string>
 #include <vector>
 
+#include "fmt/format.h"
 #include "stout/error.h"
 #include "stout/foreach.h"
 #include "stout/nothing.h"
 #include "stout/os.h"
+// Since 'fmt' library doesn't support 'wide' conversion (e.g
+// from 'std::wstring' to 'std::string' and vice versa) we use
+// API from 'include/stout/stringify.h' (e.g:
+// std::string stringify(const std::wstring& wstr) - function).
+// Check the issue for fmt conversion on github:
+// https://github.com/fmtlib/fmt/issues/1116
 #include "stout/stringify.h"
 #include "stout/try.h"
 #include "stout/windows.h" // For `iphlpapi.h`.
@@ -79,7 +86,7 @@ inline Try<std::string> getHostname(const IP& ip) {
       break;
     }
     default: {
-      ABORT("Unsupported family type: " + stringify(ip.family()));
+      ABORT(fmt::format("Unsupported family type: {}", ip.family()));
     }
   }
 
@@ -91,7 +98,7 @@ inline Try<std::string> getHostname(const IP& ip) {
   } else if (ip.family() == AF_INET6) {
     length = sizeof(struct sockaddr_in6);
   } else {
-    return Error("Unknown address family: " + stringify(ip.family()));
+    return Error(fmt::format("Unknown address family: {}", ip.family()));
   }
 
   int error = GetNameInfoW(

--- a/tests/bytes_tests.cc
+++ b/tests/bytes_tests.cc
@@ -13,9 +13,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "fmt/format.h"
 #include "stout/bytes.h"
 #include "stout/gtest.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 
@@ -62,15 +62,15 @@ TEST(BytesTest, Comparison) {
 TEST(BytesTest, Stringify) {
   EXPECT_NE(Megabytes(1023), Gigabytes(1));
 
-  EXPECT_EQ("0B", stringify(Bytes()));
+  EXPECT_EQ("0B", fmt::format("{}", Bytes()));
 
-  EXPECT_EQ("1KB", stringify(Kilobytes(1)));
-  EXPECT_EQ("1MB", stringify(Megabytes(1)));
-  EXPECT_EQ("1GB", stringify(Gigabytes(1)));
-  EXPECT_EQ("1TB", stringify(Terabytes(1)));
+  EXPECT_EQ("1KB", fmt::format("{}", Kilobytes(1)));
+  EXPECT_EQ("1MB", fmt::format("{}", Megabytes(1)));
+  EXPECT_EQ("1GB", fmt::format("{}", Gigabytes(1)));
+  EXPECT_EQ("1TB", fmt::format("{}", Terabytes(1)));
 
-  EXPECT_EQ("1023B", stringify(Bytes(1023)));
-  EXPECT_EQ("1023KB", stringify(Kilobytes(1023)));
-  EXPECT_EQ("1023MB", stringify(Megabytes(1023)));
-  EXPECT_EQ("1023GB", stringify(Gigabytes(1023)));
+  EXPECT_EQ("1023B", fmt::format("{}", Bytes(1023)));
+  EXPECT_EQ("1023KB", fmt::format("{}", Kilobytes(1023)));
+  EXPECT_EQ("1023MB", fmt::format("{}", Megabytes(1023)));
+  EXPECT_EQ("1023GB", fmt::format("{}", Gigabytes(1023)));
 }

--- a/tests/duration_tests.cc
+++ b/tests/duration_tests.cc
@@ -13,9 +13,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "fmt/format.h"
 #include "stout/duration.h"
 #include "stout/gtest.h"
-#include "stout/stringify.h"
 #include "stout/try.h"
 
 
@@ -49,7 +49,7 @@ TEST(DurationTest, ParseAndTry) {
 
   EXPECT_ERROR(
       Duration::parse(
-          stringify(std::numeric_limits<int64_t>::max()) + "seconds"));
+          fmt::format("{}seconds", std::numeric_limits<int64_t>::max())));
 
   EXPECT_SOME_EQ(Nanoseconds(3141592653), Duration::create(3.141592653));
 
@@ -88,32 +88,32 @@ TEST(DurationTest, Arithmetic) {
 
 
 TEST(DurationTest, OutputFormat) {
-  EXPECT_EQ("1ns", stringify(Nanoseconds(1)));
-  EXPECT_EQ("2ns", stringify(Nanoseconds(2)));
+  EXPECT_EQ("1ns", fmt::format("{}", Nanoseconds(1)));
+  EXPECT_EQ("2ns", fmt::format("{}", Nanoseconds(2)));
 
   // Truncated. Seconds in 15 digits of precision, max of double
   // type's precise digits.
   EXPECT_EQ(
       "3.141592653secs",
-      stringify(Duration::create(3.14159265358979).get()));
-  EXPECT_EQ("3140ms", stringify(Duration::create(3.14).get()));
-  EXPECT_EQ("10hrs", stringify(Hours(10)));
-  EXPECT_EQ("-10hrs", stringify(Hours(-10)));
+      fmt::format("{}", Duration::create(3.14159265358979).get()));
+  EXPECT_EQ("3140ms", fmt::format("{}", Duration::create(3.14).get()));
+  EXPECT_EQ("10hrs", fmt::format("{}", Hours(10)));
+  EXPECT_EQ("-10hrs", fmt::format("{}", Hours(-10)));
 
   // "10days" reads better than "1.42857142857143weeks" so it is
   // printed out in the lower unit.
-  EXPECT_EQ("10days", stringify(Days(10)));
+  EXPECT_EQ("10days", fmt::format("{}", Days(10)));
   // We go one-level down and it is still not a whole number so we
   // print it out using the higher unit.
-  EXPECT_EQ("1.1875days", stringify(Days(1) + Hours(4) + Minutes(30)));
+  EXPECT_EQ("1.1875days", fmt::format("{}", Days(1) + Hours(4) + Minutes(30)));
   // "2weeks" reads better than "14days" so we use the higher unit
   // here.
-  EXPECT_EQ("2weeks", stringify(Days(14)));
+  EXPECT_EQ("2weeks", fmt::format("{}", Days(14)));
 
   // Boundary cases.
-  EXPECT_EQ("0ns", stringify(Duration::zero()));
-  EXPECT_EQ("15250.2844524715weeks", stringify(Duration::max()));
-  EXPECT_EQ("-15250.2844524715weeks", stringify(Duration::min()));
+  EXPECT_EQ("0ns", fmt::format("{}", Duration::zero()));
+  EXPECT_EQ("15250.2844524715weeks", fmt::format("{}", Duration::max()));
+  EXPECT_EQ("-15250.2844524715weeks", fmt::format("{}", Duration::min()));
 }
 
 

--- a/tests/interval_tests.cc
+++ b/tests/interval_tests.cc
@@ -12,9 +12,9 @@
 
 #include <gtest/gtest.h>
 
+#include "fmt/format.h"
 #include "stout/foreach.h"
 #include "stout/interval.h"
-#include "stout/stringify.h"
 
 
 TEST(IntervalTest, Interval) {
@@ -369,24 +369,32 @@ TEST(IntervalTest, IntervalIteration) {
 
 
 TEST(IntervalTest, Stream) {
-  EXPECT_EQ("[1,3)", stringify((Bound<int>::closed(1), Bound<int>::open(3))));
-  EXPECT_EQ("[1,4)", stringify((Bound<int>::open(0), Bound<int>::closed(3))));
+  EXPECT_EQ(
+      "[1,3)",
+      fmt::format("{}", (Bound<int>::closed(1), Bound<int>::open(3))));
+  EXPECT_EQ(
+      "[1,4)",
+      fmt::format("{}", (Bound<int>::open(0), Bound<int>::closed(3))));
   EXPECT_EQ(
       "[0,5)",
-      stringify((Bound<int>::closed(0), Bound<int>::closed(4))));
-  EXPECT_EQ("[2,3)", stringify((Bound<int>::open(1), Bound<int>::open(3))));
-  EXPECT_EQ("[)", stringify((Bound<int>::closed(1), Bound<int>::open(1))));
+      fmt::format("{}", (Bound<int>::closed(0), Bound<int>::closed(4))));
+  EXPECT_EQ(
+      "[2,3)",
+      fmt::format("{}", (Bound<int>::open(1), Bound<int>::open(3))));
+  EXPECT_EQ(
+      "[)",
+      fmt::format("{}", (Bound<int>::closed(1), Bound<int>::open(1))));
 
   IntervalSet<int> set;
 
   set += (Bound<int>::open(7), Bound<int>::closed(9));
-  EXPECT_EQ("{[8,10)}", stringify(set));
+  EXPECT_EQ("{[8,10)}", fmt::format("{}", set));
 
   set += 5;
-  EXPECT_EQ("{[5,6)[8,10)}", stringify(set));
+  EXPECT_EQ("{[5,6)[8,10)}", fmt::format("{}", set));
 
   set += (Bound<int>::closed(7), Bound<int>::closed(9));
-  EXPECT_EQ("{[5,6)[7,10)}", stringify(set));
+  EXPECT_EQ("{[5,6)[7,10)}", fmt::format("{}", set));
 }
 
 

--- a/tests/ip_tests.cc
+++ b/tests/ip_tests.cc
@@ -17,12 +17,12 @@
 #include <string>
 #include <vector>
 
+#include "fmt/format.h"
 #include "stout/foreach.h"
 #include "stout/gtest.h"
 #include "stout/ip.h"
 #include "stout/net.h"
 #include "stout/numify.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 
 using std::set;
@@ -41,7 +41,7 @@ TEST(NetTest, LinkDevice) {
     EXPECT_FALSE(network.isError());
 
     if (network.isSome()) {
-      string addr = stringify(network.get());
+      string addr = fmt::format("{}", network.get());
       string prefix = addr.substr(addr.find('/') + 1);
       ASSERT_SOME(numify<int>(prefix));
       EXPECT_EQ(network->prefix(), numify<int>(prefix).get());
@@ -179,10 +179,10 @@ TEST(NetTest, ConstructIPv4Network) {
   ASSERT_SOME(network);
   EXPECT_EQ(net::IP(address), network->address());
   EXPECT_EQ(net::IP(netmask), network->netmask());
-  EXPECT_EQ("1.2.3.4/8", stringify(network.get()));
+  EXPECT_EQ("1.2.3.4/8", fmt::format("{}", network.get()));
 
   Try<net::IP::Network> network2 =
-      net::IP::Network::parse(stringify(network.get()));
+      net::IP::Network::parse(fmt::format("{}", network.get()));
 
   ASSERT_SOME(network2);
   EXPECT_EQ(network.get(), network2.get());
@@ -199,7 +199,7 @@ TEST(NetTest, ConstructIPv6Network) {
   EXPECT_ERROR(net::IP::Network::parse("hello moto/8"));
 
   net::IP loopback(::in6addr_loopback);
-  ASSERT_EQ("::1", stringify(loopback));
+  ASSERT_EQ("::1", fmt::format("{}", loopback));
 
   Try<net::IP> address = net::IP::parse("2001:cdba::3257:9652");
   Try<net::IP> netmask1 = net::IP::parse("ff80::"); // 9 bits
@@ -228,10 +228,10 @@ TEST(NetTest, ConstructIPv6Network) {
   ASSERT_SOME(network);
   EXPECT_EQ(address.get(), network->address());
   EXPECT_EQ(netmask1.get(), network->netmask());
-  EXPECT_EQ("2001:cdba::3257:9652/9", stringify(network.get()));
+  EXPECT_EQ("2001:cdba::3257:9652/9", fmt::format("{}", network.get()));
 
   Try<net::IP::Network> network2 =
-      net::IP::Network::parse(stringify(network.get()));
+      net::IP::Network::parse(fmt::format("{}", network.get()));
 
   ASSERT_SOME(network2);
   EXPECT_EQ(network.get(), network2.get());

--- a/tests/json_tests.cc
+++ b/tests/json_tests.cc
@@ -17,9 +17,9 @@
 
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/gtest.h"
 #include "stout/json.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 
 using std::string;
@@ -29,7 +29,7 @@ using boost::get;
 
 TEST(JsonTest, DefaultValueIsNull) {
   JSON::Value v;
-  EXPECT_EQ("null", stringify(v));
+  EXPECT_EQ("null", fmt::format("{}", v));
 }
 
 
@@ -41,7 +41,7 @@ TEST(JsonTest, UTF8) {
 
   EXPECT_EQ(
       "\"Hello! \\u0001\\u001F\\\"\\\\ \xF0\x9F\x98\x80\"",
-      stringify(s));
+      fmt::format("{}", s));
 }
 
 
@@ -52,25 +52,27 @@ TEST(JsonTest, InvalidUTF8) {
   // For now, this just gets passed through.
   JSON::String s("\xF0");
 
-  EXPECT_EQ("\"\xF0\"", stringify(s));
+  EXPECT_EQ("\"\xF0\"", fmt::format("{}", s));
 }
 
 
 TEST(JsonTest, NumberFormat) {
   // Test whole numbers (as doubles).
-  EXPECT_EQ("0.0", stringify(JSON::Number(0.0)));
-  EXPECT_EQ("1.0", stringify(JSON::Number(1.0)));
+  EXPECT_EQ("0.0", fmt::format("{}", JSON::Number(0.0)));
+  EXPECT_EQ("1.0", fmt::format("{}", JSON::Number(1.0)));
 
   // Negative.
-  EXPECT_EQ("-1.0", stringify(JSON::Number(-1.0)));
+  EXPECT_EQ("-1.0", fmt::format("{}", JSON::Number(-1.0)));
 
   // Test integers.
-  EXPECT_EQ("0", stringify(JSON::Number(0)));
-  EXPECT_EQ("2", stringify(JSON::Number(2)));
-  EXPECT_EQ("-2", stringify(JSON::Number(-2)));
+  EXPECT_EQ("0", fmt::format("{}", JSON::Number(0)));
+  EXPECT_EQ("2", fmt::format("{}", JSON::Number(2)));
+  EXPECT_EQ("-2", fmt::format("{}", JSON::Number(-2)));
 
   // Expect at least 15 digits of precision.
-  EXPECT_EQ("1234567890.12345", stringify(JSON::Number(1234567890.12345)));
+  EXPECT_EQ(
+      "1234567890.12345",
+      fmt::format("{}", JSON::Number(1234567890.12345)));
 }
 
 
@@ -101,14 +103,14 @@ TEST(JsonTest, NumberComparisons) {
 
 
 TEST(JsonTest, BooleanFormat) {
-  EXPECT_EQ("false", stringify(JSON::False()));
-  EXPECT_EQ("true", stringify(JSON::True()));
+  EXPECT_EQ("false", fmt::format("{}", JSON::False()));
+  EXPECT_EQ("true", fmt::format("{}", JSON::True()));
 
-  EXPECT_EQ("true", stringify(JSON::Boolean(true)));
-  EXPECT_EQ("false", stringify(JSON::Boolean(false)));
+  EXPECT_EQ("true", fmt::format("{}", JSON::Boolean(true)));
+  EXPECT_EQ("false", fmt::format("{}", JSON::Boolean(false)));
 
-  EXPECT_EQ("true", stringify(JSON::Value(true)));
-  EXPECT_EQ("false", stringify(JSON::Value(false)));
+  EXPECT_EQ("true", fmt::format("{}", JSON::Value(true)));
+  EXPECT_EQ("false", fmt::format("{}", JSON::Value(false)));
 }
 
 
@@ -215,18 +217,18 @@ TEST(JsonTest, Parse) {
   JSON::Object nested;
   nested.values["string"] = "string";
 
-  EXPECT_SOME_EQ(nested, JSON::parse<JSON::Object>(stringify(nested)));
+  EXPECT_SOME_EQ(nested, JSON::parse<JSON::Object>(fmt::format("{}", nested)));
 
   object.values["nested"] = nested;
 
   JSON::Array array;
   array.values.push_back(nested);
 
-  EXPECT_SOME_EQ(array, JSON::parse<JSON::Array>(stringify(array)));
+  EXPECT_SOME_EQ(array, JSON::parse<JSON::Array>(fmt::format("{}", array))));
 
   object.values["array"] = array;
 
-  EXPECT_SOME_EQ(object, JSON::parse(stringify(object)));
+  EXPECT_SOME_EQ(object, JSON::parse(fmt::format("{}", object)));
 
   // Test parsing with whitespace before and after a JSON object.
   object = JSON::Object();

--- a/tests/mac_tests.cc
+++ b/tests/mac_tests.cc
@@ -17,11 +17,11 @@
 #include <string>
 #include <vector>
 
+#include "fmt/format.h"
 #include "stout/foreach.h"
 #include "stout/gtest.h"
 #include "stout/mac.h"
 #include "stout/net.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 
 using std::set;
@@ -38,9 +38,9 @@ TEST(NetTest, Mac) {
     EXPECT_FALSE(mac.isError());
 
     if (mac.isSome()) {
-      EXPECT_NE("00:00:00:00:00:00", stringify(mac.get()));
+      EXPECT_NE("00:00:00:00:00:00", fmt::format("{}", mac.get()));
 
-      vector<string> tokens = strings::split(stringify(mac.get()), ":");
+      vector<string> tokens = strings::split(fmt::format("{}", mac.get()), ":");
       EXPECT_EQ(6u, tokens.size());
 
       for (size_t i = 0; i < tokens.size(); i++) {
@@ -61,7 +61,7 @@ TEST(NetTest, Mac) {
 TEST(NetTest, ConstructMAC) {
   uint8_t bytes[6] = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc};
 
-  EXPECT_EQ("12:34:56:78:9a:bc", stringify(net::MAC(bytes)));
+  EXPECT_EQ("12:34:56:78:9a:bc", fmt::format("{}", net::MAC(bytes)));
 }
 
 

--- a/tests/protobuf_tests.cc
+++ b/tests/protobuf_tests.cc
@@ -16,12 +16,12 @@
 #include <algorithm>
 #include <string>
 
+#include "fmt/format.h"
 #include "protobuf_tests.pb.h"
 #include "stout/gtest.h"
 #include "stout/json.h"
 #include "stout/jsonify.h"
 #include "stout/protobuf.h"
-#include "stout/stringify.h"
 #include "stout/strings.h"
 #include "stout/uuid.h"
 
@@ -175,7 +175,7 @@ TEST(ProtobufTest, JSON) {
 
   JSON::Object object = JSON::protobuf(message);
 
-  EXPECT_EQ(expected, stringify(object));
+  EXPECT_EQ(expected, fmt::format("{}", object));
 
   // Test parsing too.
   Try<tests::Message> parse = protobuf::parse<tests::Message>(object);
@@ -206,7 +206,7 @@ TEST(ProtobufTest, JSON) {
   EXPECT_EQ(object, JSON::protobuf(parse.get()));
 
   // Now convert JSON to string and parse it back as JSON.
-  ASSERT_SOME_EQ(object, JSON::parse(stringify(object)));
+  ASSERT_SOME_EQ(object, JSON::parse(fmt::format("{}", object)));
 }
 
 
@@ -248,7 +248,7 @@ TEST(ProtobufTest, JSONArray) {
 
   JSON::Array array = JSON::protobuf(arrayMessage.values());
 
-  EXPECT_EQ(expected, stringify(array));
+  EXPECT_EQ(expected, fmt::format("{}", array));
 }
 
 
@@ -313,7 +313,7 @@ TEST(ProtobufTest, JsonLargeIntegers) {
 
   // Check JSON -> String.
   JSON::Object object = JSON::protobuf(message);
-  EXPECT_EQ(expected, stringify(object));
+  EXPECT_EQ(expected, fmt::format("{}", object));
 
   // Check JSON -> Protobuf.
   Try<tests::Message> parse = protobuf::parse<tests::Message>(object);
@@ -823,7 +823,7 @@ TEST(ProtobufTest, JsonifyMap) {
       expected.end());
 
   JSON::Object object = JSON::protobuf(message);
-  EXPECT_EQ(expected, stringify(object));
+  EXPECT_EQ(expected, fmt::format("{}", object));
 
   // Test parsing too.
   Try<tests::MapMessage> parse = protobuf::parse<tests::MapMessage>(object);

--- a/tests/variant_tests.cc
+++ b/tests/variant_tests.cc
@@ -14,8 +14,8 @@
 
 #include <string>
 
+#include "fmt/format.h"
 #include "stout/gtest.h"
-#include "stout/stringify.h"
 #include "stout/variant.h"
 
 
@@ -36,7 +36,7 @@ TEST(VariantTest, Visit) {
   EXPECT_EQ(
       "hello world",
       v1.visit(
-          [](int i) { return stringify(i); },
+          [](int i) { return fmt::format("{}", i); },
           [](const std::string& s) { return s; }));
 
   // NOTE: we're explicitly using `const` here as it tests both that
@@ -56,7 +56,7 @@ TEST(VariantTest, Visit) {
   EXPECT_EQ(
       "42",
       v2.visit(
-          [](int i) { return stringify(i); },
+          [](int i) { return fmt::format("{}", i); },
           [](const std::string& s) { return s; }));
 }
 

--- a/tests/version_tests.cc
+++ b/tests/version_tests.cc
@@ -17,9 +17,9 @@
 #include <utility>
 #include <vector>
 
+#include "fmt/format.h"
 #include "stout/foreach.h"
 #include "stout/gtest.h"
-#include "stout/stringify.h"
 #include "stout/version.h"
 
 using std::map;
@@ -139,7 +139,7 @@ TEST(VersionTest, ParseValid) {
 
     EXPECT_EQ(std::get<0>(expected), actual.get())
         << "Incorrect parse of input '" << input << "'";
-    EXPECT_EQ(std::get<1>(expected), stringify(actual.get()))
+    EXPECT_EQ(std::get<1>(expected), fmt::format("{}", actual.get()))
         << "Unexpected stringify output for input '" << input << "'";
   }
 }


### PR DESCRIPTION
Replace manual stringification with [`fmt::format`](https://github.com/fmtlib/fmt#examples).