### PR TITLE
Replace 'stout::Try' with 'tl::expected'

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -97,5 +97,6 @@ cc_library(
         "@com_github_google_glog//:glog",
         "@com_github_kazuho_picojson//:picojson",
         "@com_github_tencent_rapidjson//:rapidjson",
+        "@com_github_tl_expected//:expected",
     ],
 )

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -2,6 +2,7 @@
 
 load("@com_github_3rdparty_bazel_rules_picojson//bazel:deps.bzl", picojson_deps = "deps")
 load("@com_github_3rdparty_bazel_rules_rapidjson//bazel:deps.bzl", rapidjson_deps = "deps")
+load("@com_github_3rdparty_bazel_rules_tl_expected//bazel:deps.bzl", expected_deps = "deps")
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
@@ -12,6 +13,10 @@ def deps(repo_mapping = {}):
         repo_mapping (str): {}.
     """
     boost_deps()
+
+    expected_deps(
+        repo_mapping = repo_mapping,
+    )
 
     picojson_deps(
         repo_mapping = repo_mapping,

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -112,6 +112,17 @@ def repos(external = True, repo_mapping = {}):
         ],
     )
 
+    # Get the latest bazel rules for tl::expected.
+    # https://github.com/TartanLlama/expected
+    maybe(
+        git_repository,
+        name = "com_github_3rdparty_bazel_rules_tl_expected",
+        remote = "https://github.com/3rdparty/bazel-rules-expected",
+        commit = "c703632657bf4ec9177d9aea0447166d424b3b74",
+        shallow_since = "1654243887 +0300",
+        repo_mapping = repo_mapping,
+    )
+
     if external:
         maybe(
             git_repository,


### PR DESCRIPTION
This PR replaces `stout::Try` with `stout::expected` which is just going to be an alias for [`tl::expected`](https://github.com/TartanLlama/expected).