### PR TITLE
Construct objects using direct initialization

### DIFF
--- a/tests/borrowed_ptr.cc
+++ b/tests/borrowed_ptr.cc
@@ -349,7 +349,7 @@ TEST(BorrowTest, MoveBorrowable) {
 
   atomic<bool> moving(false);
 
-  auto t = thread([&]() {
+  thread t([&]() {
     moving.store(true);
     Borrowable<string> moved = std::move(s);
     moving.store(false);


### PR DESCRIPTION
Direct initialization is simpler than copy initialization, and shorter
(you don't need to specify the type / constructor name on both the LHS
and RHS of the initialization line).

These two forms should have the same effect in C++17:
https://stackoverflow.com/a/41891708 pre-C++17, direct initialization
was typically faster / simpler (since copy initialization might incur
copies).
