### PR TITLE
Use overload parsers for defaults

### DIFF
--- a/include/stout/flags/flags.cc
+++ b/include/stout/flags/flags.cc
@@ -582,18 +582,17 @@ void Parser::Parse(const std::vector<ArgumentInfo>& values) {
     const stout::v1::Flag& flag =
         field->options().GetExtension(stout::v1::flag);
 
-    // Need to normalize string default value before parsing.
-    // NOTE: for some reason protoc compiler has generated
-    // 'default_()' method with underscore, we believe that
-    // this happens because 'default' conflicts with reserved
-    // words.
-    const std::string normalized_value =
-        GetNormalizedDefaultValue(
-            flag.default_(),
-            field->type());
-
     if (!flag.required()) {
       if (flag.has_default_()) {
+        // Need to normalize string default value before parsing.
+        // NOTE: for some reason protoc compiler has generated
+        // 'default_()' method with underscore, we believe that this
+        // happens because 'default' conflicts with reserved words.
+        const std::string normalized_value =
+            GetNormalizedDefaultValue(
+                flag.default_(),
+                field->type());
+
         SetFieldMessageOrAggregateErrors(
             normalized_value,
             name,
@@ -638,12 +637,12 @@ void Parser::Parse(const std::vector<ArgumentInfo>& values) {
         pos_arg.field->options().GetExtension(stout::v1::argument);
 
     // Need to normalize string default value before parsing.
-    const std::string normalized_value =
-        GetNormalizedDefaultValue(
-            argument.default_(),
-            pos_arg.field->type());
-
     if (argument.has_default_()) {
+      const std::string normalized_value =
+          GetNormalizedDefaultValue(
+              argument.default_(),
+              pos_arg.field->type());
+
       SetFieldMessageOrAggregateErrors(
           normalized_value,
           pos_arg.name,

--- a/include/stout/flags/flags.cc
+++ b/include/stout/flags/flags.cc
@@ -585,6 +585,7 @@ void Parser::Parse(const std::vector<ArgumentInfo>& values) {
     if (!flag.required()) {
       if (flag.has_default_()) {
         // Need to normalize string default value before parsing.
+        //
         // NOTE: for some reason protoc compiler has generated
         // 'default_()' method with underscore, we believe that this
         // happens because 'default' conflicts with reserved words.
@@ -637,6 +638,10 @@ void Parser::Parse(const std::vector<ArgumentInfo>& values) {
         pos_arg.field->options().GetExtension(stout::v1::argument);
 
     // Need to normalize string default value before parsing.
+    //
+    // NOTE: for some reason protoc compiler has generated
+    // 'default_()' method with underscore, we believe that this
+    // happens because 'default' conflicts with reserved words.
     if (argument.has_default_()) {
       const std::string normalized_value =
           GetNormalizedDefaultValue(

--- a/include/stout/flags/flags.h
+++ b/include/stout/flags/flags.h
@@ -228,6 +228,11 @@ class ParserBuilder {
           absl::Duration d;
           std::string error;
           if (!absl::AbslParseFlag(value, &d, &error)) {
+            if (error.empty()) {
+              error =
+                  "you need to provide a value with units, e.g., "
+                  "'1m' or '1m30s' or '250ms', etc";
+            }
             return std::optional<std::string>(error);
           } else {
             duration.set_seconds(

--- a/tests/flags/default_values.cc
+++ b/tests/flags/default_values.cc
@@ -1,5 +1,6 @@
 #include <array>
 
+#include "google/protobuf/util/time_util.h"
 #include "gtest/gtest.h"
 #include "stout/flags/flags.h"
 #include "tests/flags/test_default_values.pb.h"
@@ -27,6 +28,12 @@ TEST(FlagsTest, FlagsWithDefaultValues) {
   EXPECT_TRUE(flags.bar());
   EXPECT_EQ(1994, flags.baz());
   EXPECT_FALSE(flags.bam());
+  EXPECT_EQ(
+      std::chrono::nanoseconds(
+          ::google::protobuf::util::TimeUtil::DurationToNanoseconds(
+              flags.duration())),
+      std::chrono::nanoseconds(
+          std::chrono::seconds(42)));
 }
 
 TEST(FlagsTest, PositionalArgsWithDefaultValues) {

--- a/tests/flags/test_default_values.proto
+++ b/tests/flags/test_default_values.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package test.default_values;
 
+import "google/protobuf/duration.proto";
 import "include/stout/flags/v1/flag.proto";
 import "include/stout/flags/v1/positional_argument.proto";
 import "include/stout/flags/v1/subcommand.proto";
@@ -56,6 +57,14 @@ message Flags {
     (stout.v1.flag) = {
       names: [ "bam" ]
       default: "true"
+      help: "help"
+    }
+  ];
+
+  google.protobuf.Duration duration = 7 [
+    (stout.v1.flag) = {
+      names: [ "duration" ]
+      default: "42s"
       help: "help"
     }
   ];


### PR DESCRIPTION
This PR fixes a bug where we didn't correctly use overload parsers with defaults.

This PR contains multiple commits including small bug fixes and helpers necessary for using the default `google::protobuf::Duration` overload parser.