### PR TITLE
Upgrade to latest `rules_boost`

### DIFF
--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -44,9 +44,9 @@ def repos(external = True, repo_mapping = {}):
     maybe(
         git_repository,
         name = "com_github_nelhage_rules_boost",
-        commit = "494ddf5db56580eb019479965fa2908ce6548385",
+        commit = "28a32b81d829e49979475d9c539b297f88712006",
         remote = "https://github.com/nelhage/rules_boost",
-        shallow_since = "1675669198 -0800",
+        shallow_since = "1705205029 +0000",
     )
 
     maybe(


### PR DESCRIPTION
Last week's update of `boost`,
https://github.com/3rdparty/stout/pull/69, ran into nelhage/rules_boost#535. Now that that issue has been fixed, we can complete the update by going all the way to the latest `rules_boost`.