### PR TITLE
Revert "Upgrade to latest `rules_boost`"

### DIFF
--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -44,9 +44,9 @@ def repos(external = True, repo_mapping = {}):
     maybe(
         git_repository,
         name = "com_github_nelhage_rules_boost",
-        commit = "28a32b81d829e49979475d9c539b297f88712006",
+        commit = "494ddf5db56580eb019479965fa2908ce6548385",
         remote = "https://github.com/nelhage/rules_boost",
-        shallow_since = "1705205029 +0000",
+        shallow_since = "1675669198 -0800",
     )
 
     maybe(


### PR DESCRIPTION
Reverts 3rdparty/stout#70

Alas, that change causes a failure when pulled  `reboot-dev/respect`:

```
$ bazel build //object_store:library
INFO: Invocation ID: 1c4294c4-b31d-468f-b128-9dcdea56faaf
ERROR: /home/vscode/.cache/bazel/_bazel_vscode/e9b5149ef40c40531841044f5a70254d/external/com_github_reboot_dev_zlib/BUILD.bazel:2:6: no such target '@net_zlib_zlib//:zlib': target 'zlib' not declared in package '' defined by /home/vscode/.cache/bazel/_bazel_vscode/e9b5149ef40c40531841044f5a70254d/external/net_zlib_zlib/BUILD.bazel and referenced by '@com_github_reboot_dev_zlib//:z'
INFO: Repository boost instantiated at:
  /workspaces/respect/WORKSPACE.bazel:62:5: in <toplevel>
  /workspaces/respect/bazel/deps.bzl:46:19: in deps
  /home/vscode/.cache/bazel/_bazel_vscode/e9b5149ef40c40531841044f5a70254d/external/com_github_3rdparty_eventuals/bazel/deps.bzl:103:15: in deps
  /home/vscode/.cache/bazel/_bazel_vscode/e9b5149ef40c40531841044f5a70254d/external/com_github_3rdparty_stout/bazel/deps.bzl:14:15: in deps
  /home/vscode/.cache/bazel/_bazel_vscode/e9b5149ef40c40531841044f5a70254d/external/com_github_nelhage_rules_boost/boost/boost.bzl:156:10: in boost_deps
  /home/vscode/.cache/bazel/_bazel_vscode/e9b5149ef40c40531841044f5a70254d/external/bazel_tools/tools/build_defs/repo/utils.bzl:233:18: in maybe
Repository rule http_archive defined at:
  /home/vscode/.cache/bazel/_bazel_vscode/e9b5149ef40c40531841044f5a70254d/external/bazel_tools/tools/build_defs/repo/http.bzl:355:31: in <toplevel>
ERROR: Analysis of target '//object_store:library' failed; build aborted: 
INFO: Elapsed time: 2.087s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
    Fetching https://github.com/boostorg/boost/releases/download/boost-1.84.0/boost-1.84.0.tar.gz
```

It looks like we'll need to debug the new zlib issue (some conflict?), but in the meantime let's get back to a working state.