### PR TITLE
Add missing duration proto dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,6 +49,7 @@ cc_library(
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
+        "@com_google_protobuf//:duration_cc_proto",
     ],
 )
 


### PR DESCRIPTION
This doesn't cause a compilation error when built out of the box, but the error seems to manifest when built with different versions of Protobuf.